### PR TITLE
Fix dead seamless trigger on devices without a keyboard button (Legion Go 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ The button is remapped to fire a **DBus event** rather than a keystroke, so
 nothing else reacts to it. Key taps go through **`/dev/uinput`** at the kernel
 level — which is why they reach any app.
 
+## No keyboard at all? Read this
+
+If you installed an earlier version on a **Legion Go 1** — or on a Steam Deck / ROG Ally
+running Bazzite or ChimeraOS — you may have ended up with *no* on-screen keyboard. Sorry.
+The installer picked its "seamless" trigger by looking at InputPlumber's default profile,
+which advertises a keyboard button on every device, and remapped a button your hardware
+never actually sends. Meanwhile it kept Steam's own keyboard transparent. Both keyboards
+gone.
+
+Fix it either way:
+
+```bash
+handheld-kbd-recover          # puts Steam's keyboard back, switches this one to mirror mode
+./install.sh                  # re-running the installer now repairs the same thing
+```
+
+Or double-click **`Recover My Keyboard.desktop`** in this folder — no typing required, which
+rather matters when you have no keyboard.
+
+Want out entirely? `handheld-kbd-recover --stock-only` stands everything down and hands the
+desktop back to Steam's keyboard.
+
 ## Configure
 
 Everything's in `~/.config/handheld-kbd/config.json` — `opacity`, `layout`,

--- a/Recover My Keyboard.desktop
+++ b/Recover My Keyboard.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Recover My Keyboard
+Comment=No on-screen keyboard at all? This puts Steam's back and switches to mirror mode.
+Icon=edit-undo
+Terminal=true
+Exec=bash -c 'f="%k"; f="${f#file://}"; cd "$(dirname "$f")" && chmod +x ./bin/handheld-kbd-recover 2>/dev/null; ./bin/handheld-kbd-recover; echo; read -rp "Press Enter to close."'
+Categories=Utility;System;

--- a/bin/handheld-kbd-ip-remap
+++ b/bin/handheld-kbd-ip-remap
@@ -34,11 +34,34 @@ if old not in src:
     sys.exit(1)          # default profile changed shape; bail rather than guess
 open(sys.argv[2], "w").write(src.replace(old, new).replace("name: Default", "name: Better Handheld Keyboard"))
 PY
-[ -f "$PROF" ] || exit 0
+if [ ! -f "$PROF" ]; then
+    echo "handheld-kbd: InputPlumber default profile has an unexpected shape — no remap applied" >&2
+    exit 1
+fi
 
-# Apply to every InputPlumber composite device (the Legion controller)
+# Apply to every InputPlumber composite device (the Legion controller), then read the
+# profile name back so a silent failure is visible instead of looking like success.
+applied=0
 for dev in $(busctl --system tree org.shadowblip.InputPlumber 2>/dev/null \
              | grep -oE '/org/shadowblip/InputPlumber/CompositeDevice[0-9]+'); do
     busctl --system call org.shadowblip.InputPlumber "$dev" \
         org.shadowblip.Input.CompositeDevice LoadProfilePath s "$PROF" 2>/dev/null
+    name=$(busctl --system get-property org.shadowblip.InputPlumber "$dev" \
+        org.shadowblip.Input.CompositeDevice ProfileName 2>/dev/null)
+    case "$name" in *"Better Handheld Keyboard"*) applied=$((applied+1)) ;; esac
+
+    # A remap that loads is still useless if the device can't emit the button it rebinds
+    # (Legion Go 1 advertises Gamepad:Button:Keyboard but no physical button sends it).
+    caps=$(busctl --system get-property org.shadowblip.InputPlumber "$dev" \
+        org.shadowblip.Input.CompositeDevice Capabilities 2>/dev/null)
+    case "$caps" in
+        *Keyboard*) : ;;
+        *) echo "handheld-kbd: $dev does not report a keyboard button — the seamless trigger will never fire here" >&2 ;;
+    esac
 done
+
+if [ "$applied" = 0 ]; then
+    echo "handheld-kbd: profile did not load on any InputPlumber device — seamless trigger inactive" >&2
+    exit 1
+fi
+echo "handheld-kbd: seamless profile active on $applied InputPlumber device(s)" >&2

--- a/bin/handheld-kbd-recover
+++ b/bin/handheld-kbd-recover
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Better Handheld Keyboard — recovery.
+#
+# For anyone left with NO on-screen keyboard at all. That happened on devices where the
+# installer picked seamless mode from InputPlumber's generic default profile: the hardware
+# keyboard button was remapped to a DBus event the device can never emit (Legion Go 1, and
+# a Steam Deck or ROG Ally under Bazzite/ChimeraOS), while the KWin script kept Steam's own
+# keyboard fully transparent. Result: our trigger dead, Steam's keyboard invisible.
+#
+# This puts both keyboards back:
+#   • switches to mirror mode, so the button that opens Steam's keyboard opens ours
+#   • restores InputPlumber's stock profile
+#   • stops forcing Steam's keyboard transparent, and clears any leftover suppression
+#
+#   handheld-kbd-recover              -> repair, keep Better Handheld Keyboard
+#   handheld-kbd-recover --stock-only -> stand down completely, leave Steam's keyboard alone
+set -uo pipefail
+export DISPLAY="${DISPLAY:-:0}"
+
+CFG="$HOME/.config/handheld-kbd/config.json"
+BIN="$HOME/.local/bin"
+OPSCRIPT="$HOME/.local/share/kwin/scripts/handheld-kbd-opacity/contents/code/main.js"
+NAME="Steam Input On-screen Keyboard"
+STOCK_ONLY=0
+[ "${1:-}" = "--stock-only" ] && STOCK_ONLY=1
+
+say() { printf '\033[1;36m::\033[0m %s\n' "$*"; }
+ok()  { printf '\033[1;32m ✓\033[0m %s\n' "$*"; }
+warn(){ printf '\033[1;33m !!\033[0m %s\n' "$*"; }
+
+say "Recovering the on-screen keyboard…"
+
+# --- 1. stop our daemon so it can't re-apply anything mid-repair ---
+pkill -f 'handheld-kbd-swap\.sh' 2>/dev/null && ok "stopped the swap daemon" || true
+
+# --- 2. unload the KWin script that hides Steam's keyboard ---
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript handheld-kbd-opacity >/dev/null 2>&1 \
+    && ok "unloaded the KWin opacity script" || true
+
+# --- 3. restore InputPlumber's stock button mapping ---
+DEFAULT=/usr/share/inputplumber/profiles/default.yaml
+if [ -f "$DEFAULT" ] && command -v busctl >/dev/null 2>&1; then
+    restored=0
+    for dev in $(busctl --system tree org.shadowblip.InputPlumber 2>/dev/null \
+                 | grep -oE '/org/shadowblip/InputPlumber/CompositeDevice[0-9]+'); do
+        busctl --system call org.shadowblip.InputPlumber "$dev" \
+            org.shadowblip.Input.CompositeDevice LoadProfilePath s "$DEFAULT" >/dev/null 2>&1 \
+            && restored=$((restored+1))
+    done
+    [ "$restored" -gt 0 ] && ok "restored InputPlumber's stock profile on $restored device(s)" \
+                          || warn "no InputPlumber devices responded — nothing to restore"
+fi
+
+# --- 4. un-hide any Steam keyboard window we made transparent, and drop the latch ---
+rm -f /tmp/handheld-kbd.suppress
+if command -v xwininfo >/dev/null 2>&1; then
+    for w in $(xwininfo -root -tree 2>/dev/null | grep -i "$NAME" | grep -oE '0x[0-9a-f]+'); do
+        xprop -id "$w" -remove _NET_WM_WINDOW_OPACITY 2>/dev/null
+        command -v xdotool >/dev/null 2>&1 && xdotool windowmap "$w" 2>/dev/null
+    done
+    ok "cleared the opacity override on Steam's keyboard"
+fi
+
+if [ "$STOCK_ONLY" = 1 ]; then
+    pkill -f 'python3 .*handheld-kbd\.py' 2>/dev/null || true
+    rm -f "$HOME/.config/autostart/handheld-kbd.desktop" \
+          "$HOME/.config/autostart/handheld-kbd-swap.desktop"
+    ok "autostart disabled — Steam's keyboard is back on its own"
+    echo
+    say "Done. Press the button that normally opens the Steam keyboard."
+    say "Reinstall later with ./install.sh (your config is untouched)."
+    exit 0
+fi
+
+# --- 5. switch to mirror mode: works on every KDE handheld, no hardware button needed ---
+if [ -f "$CFG" ]; then
+    python3 - "$CFG" <<'PY' && ok "switched to mirror mode"
+import json,sys
+p=sys.argv[1]
+try: d=json.load(open(p))
+except Exception: d={}
+d['mirror']=True
+json.dump(d,open(p,'w'),indent=2)
+PY
+else
+    warn "no config at $CFG — run ./install.sh first"
+fi
+
+# --- 6. bring the daemon back ---
+if [ -x "$BIN/handheld-kbd-swap.sh" ]; then
+    setsid "$BIN/handheld-kbd-swap.sh" </dev/null >/dev/null 2>&1 &
+    sleep 2
+    pgrep -f 'handheld-kbd-swap\.sh' >/dev/null && ok "swap daemon restarted" \
+        || warn "swap daemon didn't start — check /tmp/swap-startup.log"
+else
+    warn "$BIN/handheld-kbd-swap.sh missing — run ./install.sh"
+fi
+
+# --- 7. tell the user what state they're in ---
+echo
+if pgrep -f 'python3 .*handheld-kbd\.py' >/dev/null; then
+    ok "keyboard process is running"
+else
+    warn "keyboard process is not running yet — the daemon respawns it within a few seconds"
+fi
+id -nG 2>/dev/null | tr ' ' '\n' | grep -qx input \
+    && ok "you're in the 'input' group (typing will work)" \
+    || warn "you are NOT in the 'input' group — typing won't work until you log out and back in"
+
+say "Done. Press the button that normally opens the Steam keyboard — ours comes up instead."
+say "Stuck? 'handheld-kbd-recover --stock-only' hands the desktop back to Steam's keyboard."

--- a/bin/handheld-kbd-swap.sh
+++ b/bin/handheld-kbd-swap.sh
@@ -18,37 +18,63 @@ exec 9>/tmp/handheld-kbd-swap.lock
 flock -n 9 || exit 0
 
 OPSCRIPT="$HOME/.local/share/kwin/scripts/handheld-kbd-opacity/contents/code/main.js"
+PROVEN="$HOME/.local/share/handheld-kbd/trigger-proven"
 
 # Regenerate the KWin opacity script from config.json so `opacity` is configurable.
 OP=$(python3 -c 'import json,os
 try: print(float(json.load(open(os.path.expanduser("~/.config/handheld-kbd/config.json")))["opacity"]))
 except Exception: print(0.72)' 2>/dev/null)
 case "$OP" in ''|*[!0-9.]*) OP=0.72 ;; esac
-mkdir -p "$(dirname "$OPSCRIPT")"
-cat > "$OPSCRIPT" <<EOF2
-function setOp(w){
-    try {
-        var c = "" + w.resourceClass;
-        var cap = "" + w.caption;
-        if (c.indexOf("handheld-kbd") !== -1) w.opacity = $OP;
-        else if (cap.indexOf("Steam Input On-screen Keyboard") !== -1) w.opacity = 0.0;
-    } catch(e){}
+
+# Hiding Steam's OSK is only safe once we know ours can actually come up. In mirror mode
+# it can by definition — Steam's OSK is what drives ours. In seamless mode the keyboard
+# touches PROVEN the first time it is shown for real, so until that exists we leave
+# Steam's keyboard alone: a trigger that never fires must degrade to "the stock keyboard",
+# never to "no keyboard at all". (That was the Legion Go 1 case — InputPlumber's default
+# profile carries a 'Keyboard' button mapping on every device, but no Go 1 button emits it.)
+hide_steam_wanted() { { [ "$MIRROR" = 1 ] || [ -f "$PROVEN" ]; } && echo 1 || echo 0; }
+
+write_opscript() {          # $1 = 1 to also force Steam's OSK transparent
+    mkdir -p "$(dirname "$OPSCRIPT")"
+    {
+        echo 'function setOp(w){'
+        echo '    try {'
+        echo '        var c = "" + w.resourceClass;'
+        echo '        var cap = "" + w.caption;'
+        echo "        if (c.indexOf(\"handheld-kbd\") !== -1) w.opacity = $OP;"
+        [ "$1" = 1 ] && echo "        else if (cap.indexOf(\"$NAME\") !== -1) w.opacity = 0.0;"
+        echo '    } catch(e){}'
+        echo '}'
+        echo 'workspace.windowList().forEach(setOp);'
+        echo 'workspace.windowAdded.connect(setOp);'
+    } > "$OPSCRIPT"
 }
-workspace.windowList().forEach(setOp);
-workspace.windowAdded.connect(setOp);
-EOF2
+
+load_opscript() {
+    qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "handheld-kbd-opacity" >/dev/null 2>&1
+    qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "$OPSCRIPT" "handheld-kbd-opacity" >/dev/null 2>&1
+    qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.start >/dev/null 2>&1
+}
+
+HIDE_STEAM=$(hide_steam_wanted)
+write_opscript "$HIDE_STEAM"
 
 {
-  echo "STARTUP $(date) OPSCRIPT=$OPSCRIPT exists=$([ -f "$OPSCRIPT" ] && echo Y || echo N) opacity=$OP"
-  qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "handheld-kbd-opacity" 2>&1
-  echo "load: $(qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "$OPSCRIPT" "handheld-kbd-opacity" 2>&1)"
-  qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.start 2>&1
+  echo "STARTUP $(date) OPSCRIPT=$OPSCRIPT exists=$([ -f "$OPSCRIPT" ] && echo Y || echo N) opacity=$OP mirror=$MIRROR hide_steam=$HIDE_STEAM"
+  load_opscript
 } >>/tmp/swap-startup.log 2>&1
 
-# When not mirroring Steam's OSK, remap the hardware keyboard button → F13 (via
-# InputPlumber) so it toggles Better Handheld Keyboard directly instead of triggering Steam's OSK.
+# Seamless mode: remap the hardware keyboard button (via InputPlumber) so it fires our
+# DBus event instead of triggering Steam's OSK. If that remap can't be applied, fall back
+# to mirror mode for this session — better a keyboard on Steam's trigger than no keyboard.
 if [ "$MIRROR" = 0 ] && [ -x "$HOME/.local/bin/handheld-kbd-ip-remap" ]; then
-    "$HOME/.local/bin/handheld-kbd-ip-remap" >/dev/null 2>&1
+    if ! "$HOME/.local/bin/handheld-kbd-ip-remap" >>/tmp/swap-startup.log 2>&1; then
+        echo "REMAP FAILED $(date) — falling back to mirror mode" >>/tmp/swap-startup.log
+        MIRROR=1
+        HIDE_STEAM=$(hide_steam_wanted)
+        write_opscript "$HIDE_STEAM"
+        load_opscript
+    fi
 fi
 
 opcheck=99   # force an immediate opacity-script check on first loop
@@ -58,7 +84,14 @@ while true; do
     opcheck=$((opcheck+1))
     if [ "$opcheck" -ge 30 ]; then
         opcheck=0
-        if [ "$(qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.isScriptLoaded handheld-kbd-opacity 2>/dev/null)" != "true" ]; then
+        # Seamless mode: the first time the keyboard actually appears, PROVEN shows up and
+        # we may start hiding Steam's OSK. Rewrite + reload the script when that flips.
+        want=$(hide_steam_wanted)
+        if [ "$want" != "$HIDE_STEAM" ]; then
+            HIDE_STEAM=$want
+            write_opscript "$HIDE_STEAM"
+            load_opscript
+        elif [ "$(qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.isScriptLoaded handheld-kbd-opacity 2>/dev/null)" != "true" ]; then
             qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "$OPSCRIPT" "handheld-kbd-opacity" >/dev/null 2>&1
             qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.start >/dev/null 2>&1
         fi

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -432,6 +432,22 @@ def setup_hotkey(config, toggle):
 _instance_lock = None
 
 
+PROVEN = os.path.expanduser("~/.local/share/handheld-kbd/trigger-proven")
+
+
+def _mark_proven():
+    """Record that this keyboard really did come up on this machine.
+
+    The swap daemon only makes Steam's on-screen keyboard transparent once this
+    exists, so a trigger that never fires leaves the stock keyboard usable instead
+    of leaving the user with no keyboard at all."""
+    try:
+        os.makedirs(os.path.dirname(PROVEN), exist_ok=True)
+        open(PROVEN, "w").close()
+    except Exception:
+        pass
+
+
 def _single_instance():
     """Ensure only ONE keyboard runs — duplicates leave a ghost window that still
     catches taps after the visible one hides. Exit silently if already running."""
@@ -466,6 +482,7 @@ def main():
         w.show_all()
         if GAMEMODE:                      # set overlay atoms once gamescope has mapped us
             GLib.timeout_add(250, w.gm_show)
+        _mark_proven()
         _setvis("1"); return True
 
     def _hide(*_):

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,7 @@ install -m755 "$HERE/bin/handheld-kbd.py"        "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-swap.sh"   "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-relogin"   "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-ip-remap"  "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-recover"   "$BIN/"
 
 # --- config (never clobber the user's edits) ---
 FRESH=0
@@ -50,11 +51,29 @@ for f in "$HERE"/config/locales/*.json; do
 done
 
 # --- on a fresh install, auto-pick the trigger mode for this device ---
-# Seamless: if InputPlumber exposes the hardware keyboard button (Legion Go etc.),
-# remap it to summon THIS keyboard directly. Otherwise: mirror Steam's on-screen
-# keyboard (works on any KDE handheld; press the device's keyboard button).
+# Mirror mode is the default because it works on any KDE handheld: press whatever
+# summons the system on-screen keyboard and ours comes up in its place.
+#
+# Seamless mode remaps the hardware keyboard button via InputPlumber so it drives this
+# keyboard directly. It is only offered on devices that actually HAVE such a button.
+# Do NOT infer that from /usr/share/inputplumber/profiles/default.yaml — that profile
+# ships the same 'button: Keyboard' mapping on every device, so grepping it selected
+# seamless mode on hardware where no button can ever emit the event (Legion Go 1, and a
+# Steam Deck or ROG Ally under Bazzite/ChimeraOS: none of those InputPlumber drivers
+# emit GamepadButton::Keyboard). The result was a dead trigger. Match the device instead.
+SEAMLESS_DMI='83N0 83N1'        # Lenovo Legion Go 2 — has a real keyboard button
+
+seamless_supported() {
+  [ -f /usr/share/inputplumber/profiles/default.yaml ] || return 1
+  command -v busctl >/dev/null 2>&1 || return 1
+  local product
+  product="$(cat /sys/class/dmi/id/product_name 2>/dev/null)" || return 1
+  for m in $SEAMLESS_DMI; do [ "$product" = "$m" ] && return 0; done
+  return 1
+}
+
 if [ "$FRESH" = 1 ]; then
-  if grep -q 'button: Keyboard' /usr/share/inputplumber/profiles/default.yaml 2>/dev/null; then
+  if seamless_supported; then
     say "Seamless mode — your keyboard button will summon this keyboard directly."
     python3 - "$CFG/config.json" <<'PY'
 import json,sys
@@ -63,6 +82,29 @@ json.dump(d,open(p,'w'),indent=2)
 PY
   else
     say "Mirror mode — this keyboard replaces the system on-screen keyboard."
+  fi
+elif ! seamless_supported && python3 -c 'import json,os,sys
+p=os.path.expanduser("~/.config/handheld-kbd/config.json")
+try: sys.exit(0 if json.load(open(p)).get("mirror", True) is False else 1)
+except Exception: sys.exit(1)' 2>/dev/null; then
+  # Repair an existing install that an earlier version put into seamless mode on hardware
+  # that can't drive it. Left alone, the keyboard button does nothing at all.
+  warn "This device is in seamless mode but has no keyboard button that can trigger it."
+  python3 - "$CFG/config.json" <<'PY'
+import json,sys
+p=sys.argv[1]; d=json.load(open(p)); d['mirror']=True
+json.dump(d,open(p,'w'),indent=2)
+PY
+  say "Switched to mirror mode — press whatever opens the Steam keyboard."
+  pkill -f 'handheld-kbd-swap\.sh' 2>/dev/null || true
+  if [ -f /usr/share/inputplumber/profiles/default.yaml ] && command -v busctl >/dev/null 2>&1; then
+    for dev in $(busctl --system tree org.shadowblip.InputPlumber 2>/dev/null \
+                 | grep -oE '/org/shadowblip/InputPlumber/CompositeDevice[0-9]+'); do
+      busctl --system call org.shadowblip.InputPlumber "$dev" \
+        org.shadowblip.Input.CompositeDevice LoadProfilePath s \
+        /usr/share/inputplumber/profiles/default.yaml >/dev/null 2>&1
+    done
+    say "Restored InputPlumber's stock button mapping."
   fi
 fi
 
@@ -124,4 +166,5 @@ say "Done!"
 echo "   • Log out and back in once (activates autostart + permissions)."
 echo "   • Then press your device's keyboard button — this keyboard comes up instead."
 echo "   • Edit ~/.config/handheld-kbd/config.json for opacity, layout, theme, optional hotkey."
+echo "   • No keyboard at all afterwards? Run:  handheld-kbd-recover"
 [ "${PRIV_OK:-0}" = 1 ] || warn "Permission step didn't complete — typing won't work until it does."


### PR DESCRIPTION
A Legion Go 1 user installed this and ended up with **no on-screen keyboard at all** — ours never appeared, and Steam's was invisible. Root cause is our installer, not their device.

## What went wrong

`install.sh` picked the trigger mode with:

```bash
grep -q 'button: Keyboard' /usr/share/inputplumber/profiles/default.yaml
```

That file is InputPlumber's **generic** default profile — it ships the same `- name: Keyboard` mapping on [every device](https://github.com/ShadowBlip/InputPlumber/blob/main/rootfs/usr/share/inputplumber/profiles/default.yaml#L33-L41). The grep therefore matches whenever InputPlumber is merely *installed*, and we selected seamless mode on hardware that cannot drive it.

The Legion Go 1 is exactly that case. Its driver declares the capability but nothing emits it:

- `src/input/source/hidraw/legion_go2.rs` maps `GamepadButtonEvent::ShowDesktop` → `GamepadButton::Keyboard` — a real button.
- `src/input/source/hidraw/legion_go.rs` declares `GamepadButton::Keyboard` in its capability array, but its event set is only `Legion`, `QuickAccess`, `Y1`/`Y2`/`Y3`, `M2`/`M3`, `MouseClick`. No event ever produces it.

Same trap applies to a **Steam Deck or ROG Ally under Bazzite/ChimeraOS** — neither `steam_deck.rs` nor `rog_ally.rs` references `GamepadButton::Keyboard`. Stock SteamOS escapes it only because it doesn't ship InputPlumber, which is why this went unnoticed on the Deck and Go 2.

Then we made it worse: `handheld-kbd-swap.sh` generated the KWin script with the Steam-OSK rule in **every** mode, so `Steam Input On-screen Keyboard` was forced to `opacity = 0.0` even though our own trigger was dead. Our keyboard couldn't come up and Steam's couldn't be seen.

## Changes

**Detection** — `install.sh` selects seamless by DMI `product_name` (Legion Go 2: `83N0`/`83N1`) and defaults to mirror mode everywhere else. Mirror works on any KDE handheld and needs no hardware button. Deliberately *not* using InputPlumber's DBus `Capabilities` property: the Go 1 advertises `Gamepad:Button:Keyboard` there too, so it would reproduce the same false positive.

**Fail visible, not dark** — `handheld-kbd-swap.sh` only hides Steam's keyboard when ours is known to work: mirror mode qualifies by definition, and in seamless mode the keyboard touches `~/.local/share/handheld-kbd/trigger-proven` the first time it is actually shown. The daemon rewrites and reloads the KWin script when that flips. A broken trigger now degrades to "the stock keyboard", never to "no keyboard".

**Runtime fallback** — if the InputPlumber remap fails, the daemon drops to mirror mode for the session instead of leaving the user with nothing.

**Honest diagnostics** — `handheld-kbd-ip-remap` reads the `ProfileName` property back after `LoadProfilePath`, warns when a device reports no keyboard capability, and exits non-zero instead of `|| exit 0`-ing into a silent no-op.

**Repair path for existing installs** — re-running `install.sh` detects a config stuck in seamless mode on unsupported hardware, switches it to mirror, and restores InputPlumber's stock profile. Plus `bin/handheld-kbd-recover` and a double-clickable `Recover My Keyboard.desktop` (typing is not an option when you have no keyboard) which:

- switches to mirror mode
- restores InputPlumber's stock profile
- unloads the KWin opacity script and clears the `_NET_WM_WINDOW_OPACITY` override and unmap latch on Steam's keyboard
- restarts the daemon and reports whether the process is up and whether you're in the `input` group
- `--stock-only` stands everything down and hands the desktop back to Steam's keyboard

README gains a recovery section up front.

## Testing

Shell and Python syntax checked; KWin script generation verified in both the hide and no-hide forms. Not yet run on a Legion Go 1 — the detection change is device-gated, so it needs a check on that hardware before release, and confirmation from the affected user that `handheld-kbd-recover` restores their keyboard.