### PR TITLE
Predictive text, big mode and swipe typing from the Go 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ __pycache__/
 .DS_Store
 # runtime scratch (not source)
 *.log
+
+# prediction data — generated locally by handheld-kbd-build-dict, and personal.
+# ~/.local/share/handheld-kbd/{unigrams,bigrams}.txt and learned.json never belong in git.
+unigrams.txt
+bigrams.txt
+learned.json
+raw/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
+## v1.1.0 — Predictive text and a bigger keyboard
+
+Everything from v1.0.1 stays: the trigger detection fix, the fail-visible KWin rule, the
+recovery script. This adds the features that had been living on my own Legion Go 2.
+
+### Added
+
+- **Predictive text.** A row of tappable suggestions above the keys, backed by
+  `handheld_kbd_predict.py`. Learns the words you commit (`predict_learn`, stored in
+  `~/.local/share/handheld-kbd/learned.json`, never leaves the device) and blends that
+  with corpus frequencies built once by the new `handheld-kbd-build-dict`. Tapping a
+  suggestion erases the partial word and types the full one as real keystrokes, so it
+  works in any application. Falls back to a plain keyboard if the engine or its data is
+  missing, and off entirely with `"prediction": false`.
+- **Big mode.** A `size` key (⤢) toggles between `geometry` and the new `big_geometry`,
+  stretching every key to fill the window and rewriting the KWin rule live — no relogin.
+  `start_big` comes up in it.
+- **Opacity cycling.** An `opacity` key (◐) steps through `opacity_steps` and persists
+  the choice, instead of editing JSON to see what's behind the keyboard.
+- **Swipe typing.** Drag across the letters to type a word (`handheld_kbd_swipe.py`).
+  A drag only counts once it travels `swipe_min_travel` key-widths and crosses
+  `swipe_min_keys` distinct letters, so ordinary taps are untouched. Runner-up decodings
+  appear in the suggestion row.
+- **Two more ways to summon it.** `gesture_summon` shows the keyboard on a two-finger
+  swipe up from the bottom edge of the touchscreen; `show_on_focus` shows it whenever a
+  text field takes focus, via AT-SPI (`handheld-kbd-focus-probe` helps identify what the
+  bridge reports). Both show-only and both off by default.
+- **Resume handling.** `handheld-kbd-resume-watch.py` listens for logind's
+  `PrepareForSleep` and re-initialises the keyboard on wake, fixing a stale trigger or
+  uinput handle after sleep. Installed as an autostart entry.
+- **Multi-display docking.** The window anchors to the internal panel (`internal_output`,
+  auto-detecting `eDP*`) so an external display doesn't drag the keyboard off-screen.
+
+### Changed
+
+- The KWin script now also keeps the keyboard above fullscreen windows (temporarily
+  dropping the fullscreen window to `keepBelow`, restored afterwards) and re-asserts
+  focus on the window you were actually typing into when the keyboard maps.
+- `full.json` gains the ◐ and ⤢ keys.
+
+Prediction data (`unigrams.txt`, `bigrams.txt`, `learned.json`, `raw/`) is generated on
+device and git-ignored — the repo ships the builder, not the data.
+
 ## v1.0.1 — Legion Go 1 keyboard recovery
 
 **If you installed v1.0.0 on a Legion Go 1 — or on a Steam Deck or ROG Ally running Bazzite

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ So I built the keyboard I wanted instead. Here's what it does differently:
   all live in a JSON file. No code to touch.
 - **US / UK layouts.** A 🌐 key flips the layout so `£`, `@`, `#`, `"` land where
   they should.
+- **Predictive text.** A row of tappable suggestions above the keys. It learns
+  what *you* type, and `handheld-kbd-build-dict` adds corpus frequencies so it's
+  useful from the first keypress. Tapping a suggestion types it as real keys, so
+  it works in any app. Off with `"prediction": false`.
+- **Two sizes.** The ⤢ key toggles between the normal keyboard and a taller one
+  with bigger keys — thumbs on a 7-inch panel, or precision when you're docked.
+  Toggles live, no relogin.
+- **Cycle transparency from the keyboard.** The ◐ key steps through
+  `opacity_steps` instead of making you edit JSON to see what's underneath.
+- **Swipe typing.** Drag across the letters instead of tapping them. Taps are
+  unaffected — a drag only counts once it's unmistakably not one.
+- **Optional summon gestures.** Two-finger swipe up from the bottom edge
+  (`gesture_summon`), or auto-show whenever a text field takes focus
+  (`show_on_focus`, via AT-SPI). Both off by default.
+- **Survives sleep and fullscreen.** It re-initialises after resume, and stays
+  visible above fullscreen windows instead of disappearing behind them.
 
 ## Install
 
@@ -72,6 +88,24 @@ rather matters when you have no keyboard.
 
 Want out entirely? `handheld-kbd-recover --stock-only` stands everything down and hands the
 desktop back to Steam's keyboard.
+
+## Predictive text
+
+Prediction works out of the box from what you type. For suggestions that are useful
+before it has learned anything, build the corpus data once:
+
+```bash
+handheld-kbd-build-dict
+```
+
+That writes `unigrams.txt` and `bigrams.txt` into `~/.local/share/handheld-kbd/`. It
+prefers Peter Norvig's `count_1w.txt` / `count_2w.txt` if you drop them in
+`~/.local/share/handheld-kbd/raw/`, and falls back to the system aspell dictionary
+when offline. Re-runnable, and it never touches `learned.json` — that's your personal
+vocabulary, stays on the device, and is in `.gitignore` for a reason.
+
+Turn learning off with `"predict_learn": false` (corpus only), or prediction entirely
+with `"prediction": false`.
 
 ## Configure
 

--- a/autostart/handheld-kbd-resume.desktop
+++ b/autostart/handheld-kbd-resume.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Better Handheld Keyboard — resume re-init
+Comment=Re-initialise the on-screen keyboard after sleep (stale trigger / uinput handle)
+Exec=python3 __BIN__/handheld-kbd-resume-watch.py
+Terminal=false
+OnlyShowIn=KDE;
+X-KDE-autostart-after=panel
+X-GNOME-Autostart-enabled=true

--- a/bin/handheld-kbd-build-dict
+++ b/bin/handheld-kbd-build-dict
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Build the compact prediction data files for Better Handheld Keyboard.
+
+Reads the raw Google-Web-corpus n-gram lists (Peter Norvig's count_1w.txt /
+count_2w.txt, downloaded to ~/.local/share/handheld-kbd/raw/) and writes two
+small tab-separated files the keyboard loads at startup:
+
+  ~/.local/share/handheld-kbd/unigrams.txt   word <TAB> count
+  ~/.local/share/handheld-kbd/bigrams.txt    prev <TAB> word <TAB> count
+
+The raw lists are web-scraped, so the tail is mostly junk and misspellings —
+we keep the top VOCAB entries and apply a light plausibility filter. Bigrams are
+restricted to that vocabulary and capped per head word, which is what keeps the
+runtime file small enough to load instantly on a handheld.
+
+If the raw files are missing (offline install), falls back to the system aspell
+dictionary with synthetic frequencies: prediction still works, just without the
+"which word is actually common" signal.
+
+Re-runnable at any time; it never touches learned.json (your personal vocabulary).
+"""
+import os, re, sys, subprocess
+
+DATA = os.path.expanduser("~/.local/share/handheld-kbd")
+RAW = os.path.join(DATA, "raw")
+
+VOCAB = 80000          # unigrams retained
+BI_PER_HEAD = 8        # top successors kept per previous-word
+BI_MIN = 5000          # ignore very rare pairs outright
+
+WORD_RE = re.compile(r"^[a-z][a-z']{0,19}$")
+
+
+def plausible(w):
+    """Cheap junk filter for the web-corpus tail."""
+    if not WORD_RE.match(w):
+        return False
+    if len(w) == 1 and w not in ("a", "i"):
+        return False
+    if not re.search(r"[aeiouy]", w) and len(w) > 3:
+        return False          # consonant soup, e.g. scraped markup
+    if re.search(r"(.)\1\1", w):
+        return False          # 3+ repeated letters
+    if w.count("'") > 1:
+        return False
+    return True
+
+
+def build_unigrams():
+    src = os.path.join(RAW, "count_1w.txt")
+    vocab = {}
+    if os.path.exists(src):
+        with open(src, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                w, _, c = line.rstrip("\n").partition("\t")
+                w = w.lower()
+                if not plausible(w):
+                    continue
+                try:
+                    n = int(c)
+                except ValueError:
+                    continue
+                if w in vocab:
+                    vocab[w] += n          # case-folded duplicates merge
+                else:
+                    vocab[w] = n
+                    if len(vocab) >= VOCAB * 2:
+                        break
+        top = sorted(vocab.items(), key=lambda kv: -kv[1])[:VOCAB]
+        print(f"unigrams: {len(top)} from corpus")
+        return dict(top)
+
+    # ---- offline fallback: aspell wordlist, synthetic Zipf-ish frequencies ----
+    print("raw corpus missing -> falling back to aspell dictionary", file=sys.stderr)
+    try:
+        out = subprocess.check_output("aspell -d en dump master | aspell -l en expand",
+                                      shell=True, text=True, timeout=120)
+    except Exception as ex:
+        print(f"aspell fallback failed: {ex}", file=sys.stderr)
+        return {}
+    words = [w.lower() for w in out.split() if plausible(w.lower())]
+    seen = {}
+    for i, w in enumerate(dict.fromkeys(words)):
+        seen[w] = max(1, 1000000 // (i + 1))     # shorter/earlier ~ more common
+    print(f"unigrams: {len(seen)} from aspell (no real frequencies)")
+    return seen
+
+
+def build_bigrams(vocab):
+    src = os.path.join(RAW, "count_2w.txt")
+    if not os.path.exists(src):
+        print("no bigram corpus -> next-word prediction will rely on learning only",
+              file=sys.stderr)
+        return {}
+    heads = {}
+    with open(src, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            pair, _, c = line.rstrip("\n").partition("\t")
+            parts = pair.lower().split()
+            if len(parts) != 2:
+                continue
+            a, b = parts
+            if a not in vocab or b not in vocab:
+                continue
+            try:
+                n = int(c)
+            except ValueError:
+                continue
+            if n < BI_MIN:
+                continue
+            d = heads.setdefault(a, {})
+            d[b] = d.get(b, 0) + n
+    trimmed = {}
+    for a, d in heads.items():
+        top = sorted(d.items(), key=lambda kv: -kv[1])[:BI_PER_HEAD]
+        trimmed[a] = top
+    print(f"bigrams: {len(trimmed)} head words, "
+          f"{sum(len(v) for v in trimmed.values())} pairs")
+    return trimmed
+
+
+def main():
+    os.makedirs(DATA, exist_ok=True)
+    vocab = build_unigrams()
+    if not vocab:
+        print("no vocabulary could be built", file=sys.stderr)
+        return 1
+    bi = build_bigrams(vocab)
+    with open(os.path.join(DATA, "unigrams.txt"), "w") as f:
+        for w, n in sorted(vocab.items(), key=lambda kv: -kv[1]):
+            f.write(f"{w}\t{n}\n")
+    with open(os.path.join(DATA, "bigrams.txt"), "w") as f:
+        for a in sorted(bi):
+            for b, n in bi[a]:
+                f.write(f"{a}\t{b}\t{n}\n")
+    for name in ("unigrams.txt", "bigrams.txt"):
+        p = os.path.join(DATA, name)
+        print(f"wrote {p} ({os.path.getsize(p)/1024:.0f} KiB)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/handheld-kbd-focus-probe
+++ b/bin/handheld-kbd-focus-probe
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Diagnostic: watch text-field focus via BOTH AT-SPI and KWin's VirtualKeyboard.
+
+Run it in your own session, then tap into text fields in real apps (browser bar,
+KWrite, terminal, Discover search, a chat box...). Each line printed = a focus
+signal we could hang "show-on-focus" off. Ctrl+C when done and share the output.
+
+    handheld-kbd-focus-probe          # runs until Ctrl+C
+"""
+import os, sys, gi
+gi.require_version("Atspi", "2.0")
+from gi.repository import Atspi, GLib, Gio
+import subprocess
+
+# AT-SPI in some sessions can't auto-find the running a11y bus; point it there.
+if not os.environ.get("AT_SPI_BUS_ADDRESS"):
+    try:
+        addr = subprocess.check_output(
+            ["qdbus6", "org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus.GetAddress"],
+            text=True, timeout=3).strip()
+        if addr:
+            os.environ["AT_SPI_BUS_ADDRESS"] = addr
+    except Exception as ex:
+        print(f"(couldn't fetch a11y bus address: {ex})", file=sys.stderr)
+
+EDITABLE = {Atspi.Role.ENTRY, Atspi.Role.TEXT, Atspi.Role.PASSWORD_TEXT,
+            Atspi.Role.DOCUMENT_TEXT, Atspi.Role.TERMINAL, Atspi.Role.DOCUMENT_FRAME}
+n = {"atspi": 0, "kwin": 0}
+
+
+def on_focus(ev):
+    try:
+        acc = ev.source
+        st = acc.get_state_set()
+        editable = st.contains(Atspi.StateType.EDITABLE) or acc.get_role() in EDITABLE
+        if ev.detail1 == 1:      # gained focus
+            try: app = acc.get_application().get_name()
+            except Exception: app = "?"
+            tag = "EDITABLE" if editable else "focus"
+            n["atspi"] += editable
+            print(f"[AT-SPI/{tag}] role={acc.get_role_name()} app={app}", flush=True)
+    except Exception:
+        pass
+
+
+def on_props(conn, sender, path, iface, sig, params):
+    try:
+        _, changed, _ = params.unpack()
+        keys = [k for k in ("active", "activeClientSupportsTextInput", "visible") if k in changed]
+        if keys:
+            n["kwin"] += 1
+            print(f"[KWin] {{ {', '.join(f'{k}={changed[k]}' for k in keys)} }}", flush=True)
+    except Exception:
+        pass
+
+
+def main():
+    Atspi.EventListener.new(on_focus).register("object:state-changed:focused")
+    bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+    bus.signal_subscribe("org.kde.KWin", "org.freedesktop.DBus.Properties",
+                         "PropertiesChanged", "/VirtualKeyboard", None,
+                         Gio.DBusSignalFlags.NONE, on_props)
+    print(">>> Watching focus on BOTH sensors. Tap into text fields in real apps.", flush=True)
+    print(">>> Ctrl+C when done.\n", flush=True)
+    try:
+        GLib.MainLoop().run()
+    except KeyboardInterrupt:
+        print(f"\n\nsummary: AT-SPI editable-focus events={n['atspi']}  KWin change events={n['kwin']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/handheld-kbd-resume-watch.py
+++ b/bin/handheld-kbd-resume-watch.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Re-init the Better Handheld Keyboard on resume-from-sleep. Uses Gio signal_subscribe
+(a normal match rule — works as non-root, unlike dbus-monitor eavesdropping) on logind's
+PrepareForSleep signal. Argument False = waking up."""
+import os, subprocess, gi
+import fcntl
+_lk=open('/tmp/handheld-kbd-resume-watch.lock','w')
+try: fcntl.flock(_lk, fcntl.LOCK_EX|fcntl.LOCK_NB)
+except OSError: raise SystemExit(0)
+gi.require_version('GLib', '2.0')
+from gi.repository import Gio, GLib
+RESUME = os.path.expanduser('~/.local/bin/handheld-kbd-resume.sh')
+def fire():
+    subprocess.Popen(['bash', RESUME]); return False
+def on_sig(conn, sender, path, iface, signal, params):
+    try: going = params.unpack()[0]
+    except Exception: return
+    if going is False:
+        GLib.timeout_add_seconds(3, fire)
+bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+bus.signal_subscribe(None, 'org.freedesktop.login1.Manager', 'PrepareForSleep',
+                     '/org/freedesktop/login1', None, Gio.DBusSignalFlags.NONE, on_sig)
+GLib.MainLoop().run()

--- a/bin/handheld-kbd-resume-watch.sh
+++ b/bin/handheld-kbd-resume-watch.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Watches logind for resume-from-sleep and re-inits the OSK. User-level (no root).
+export DISPLAY="${DISPLAY:-:0}"
+exec 9>/tmp/handheld-kbd-resume-watch.lock; flock -n 9 || exit 0
+dbus-monitor --system "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'" 2>/dev/null |
+while read -r line; do
+  # PrepareForSleep(true)=going to sleep, (false)=resuming
+  case "$line" in
+    *"boolean false"*)
+      sleep 3            # let InputPlumber/devices settle after wake
+      "$HOME/.local/bin/handheld-kbd-resume.sh"
+      ;;
+  esac
+done

--- a/bin/handheld-kbd-resume.sh
+++ b/bin/handheld-kbd-resume.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Re-initialise the Better Handheld Keyboard after resume-from-sleep. A fresh restart
+# re-establishes the uinput device AND the InputPlumber (org.shadowblip) dbus signal
+# subscription, both of which go stale across suspend. Idempotent, no root.
+export DISPLAY="${DISPLAY:-:0}"
+# force a clean restart of the OSK process (not just "start if dead" — it IS alive but stale)
+pkill -f 'python3 .*handheld-kbd\.py' 2>/dev/null
+sleep 1
+setsid sh -c 'python3 "$HOME/.local/bin/handheld-kbd.py" >/tmp/handheld-kbd-out.log 2>&1' >/dev/null 2>&1 &
+# reassert the KWin opacity/focus script + swap daemon
+[ -x "$HOME/.local/share/system-fixes/restore-osk.sh" ] && "$HOME/.local/share/system-fixes/restore-osk.sh" >/dev/null 2>&1 || true
+exit 0

--- a/bin/handheld-kbd-swap.sh
+++ b/bin/handheld-kbd-swap.sh
@@ -35,19 +35,92 @@ case "$OP" in ''|*[!0-9.]*) OP=0.72 ;; esac
 hide_steam_wanted() { { [ "$MIRROR" = 1 ] || [ -f "$PROVEN" ]; } && echo 1 || echo 0; }
 
 write_opscript() {          # $1 = 1 to also force Steam's OSK transparent
+    if [ "$1" = 1 ]; then
+        STEAM_RULE="else if (cap.indexOf(\"$NAME\") !== -1) w.opacity = 0.0;"
+    else
+        STEAM_RULE="// Steam's OSK left alone: this keyboard has not proven it can appear yet."
+    fi
     mkdir -p "$(dirname "$OPSCRIPT")"
-    {
-        echo 'function setOp(w){'
-        echo '    try {'
-        echo '        var c = "" + w.resourceClass;'
-        echo '        var cap = "" + w.caption;'
-        echo "        if (c.indexOf(\"handheld-kbd\") !== -1) w.opacity = $OP;"
-        [ "$1" = 1 ] && echo "        else if (cap.indexOf(\"$NAME\") !== -1) w.opacity = 0.0;"
-        echo '    } catch(e){}'
-        echo '}'
-        echo 'workspace.windowList().forEach(setOp);'
-        echo 'workspace.windowAdded.connect(setOp);'
-    } > "$OPSCRIPT"
+    cat > "$OPSCRIPT" <<EOF2
+// Better Handheld Keyboard KWin helper: (1) set our OSK's opacity + hide Steam's OSK,
+// (2) keep the OSK visible above fullscreen windows (e.g. Chrome video fullscreen),
+// (3) keep keyboard focus on the window the user was on when the OSK is summoned.
+var OP = $OP;
+var demoted = {};   // internalId -> true : fullscreen windows WE dropped to keepBelow
+var lastReal = null;   // most recent focusable window the user was on (for focus restore)
+
+function isKbd(w){ return ("" + w.resourceClass).indexOf("handheld-kbd") !== -1; }
+
+function focusable(w){
+    // windows that can hold the user's typing focus: exclude our OSK and
+    // non-activating surfaces (panels/docks, desktop, OSD, notifications).
+    if (!w) return false;
+    if (isKbd(w)) return false;
+    if (w.dock || w.desktopWindow || w.onScreenDisplay || w.notification) return false;
+    return true;
+}
+
+function setOp(w){
+    try {
+        var c = "" + w.resourceClass;
+        var cap = "" + w.caption;
+        if (c.indexOf("handheld-kbd") !== -1) w.opacity = OP;
+        $STEAM_RULE
+    } catch(e){}
+}
+
+// GTK hide() destroys the OSK's Wayland surface, so a present, non-minimized
+// handheld-kbd window means the keyboard is currently shown.
+function kbdShown(){
+    var list = workspace.windowList();
+    for (var i = 0; i < list.length; i++)
+        if (isKbd(list[i]) && !list[i].minimized) return true;
+    return false;
+}
+
+// A fullscreen window sits in KWin's ActiveLayer, above the OSK's keep-above
+// AboveLayer, so it covers the keyboard. keepBelow is evaluated before
+// activeFullScreen, so dropping the fullscreen window to keepBelow (BelowLayer)
+// lets the OSK float on top. Restore it when the OSK hides / leaves fullscreen.
+function applyStack(){
+    try {
+        var shown = kbdShown();
+        var list = workspace.windowList();
+        for (var i = 0; i < list.length; i++){
+            var w = list[i];
+            if (isKbd(w)) continue;
+            var id = "" + w.internalId;
+            if (shown && w.fullScreen){
+                if (!w.keepBelow){ w.keepBelow = true; demoted[id] = true; }
+            } else if (demoted[id]){
+                w.keepBelow = false;
+                delete demoted[id];
+            }
+        }
+    } catch(e){}
+}
+
+function watch(w){
+    try { w.fullScreenChanged.connect(applyStack); w.minimizedChanged.connect(applyStack); } catch(e){}
+}
+function onAdded(w){
+    setOp(w); watch(w); applyStack();
+    // When our OSK maps, the summon (touch gesture / map) may have shifted focus.
+    // Re-assert the window the user was on so typed keys land there. keepBelow keeps
+    // a demoted fullscreen window below the OSK even once it is active again.
+    if (isKbd(w) && lastReal) {
+        // only re-activate if focus actually moved, so we don't needlessly re-raise the
+        // window and disturb the text caret when the summon didn't defocus it.
+        try { if (workspace.activeWindow !== lastReal) workspace.activeWindow = lastReal; } catch(e){}
+    }
+}
+
+workspace.windowActivated.connect(function(w){ if (focusable(w)) lastReal = w; });
+workspace.windowList().forEach(function(w){ setOp(w); watch(w); });
+workspace.windowAdded.connect(onAdded);
+workspace.windowRemoved.connect(applyStack);
+applyStack();
+EOF2
 }
 
 load_opscript() {

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -11,7 +11,7 @@ OS XKB layout. The 🌐 key switches the OS layout via KDE's KeyboardLayouts DBu
 re-skins the on-key labels to match, keeping label and output in sync.
 If any JSON is missing/invalid, built-in defaults are used so it always comes up.
 """
-import gi, sys, time, os, signal, json, subprocess
+import gi, sys, time, os, signal, json, subprocess, math
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GLib
 from evdev import UInput, ecodes as e
@@ -26,9 +26,28 @@ GS_DISPLAY = os.environ.get("HANDHELD_KBD_GS_DISPLAY", os.environ.get("DISPLAY",
 
 DEFAULT_CONFIG = {
     "layout": "full", "locale": "auto", "opacity": 0.72,
+    # Transparency cycle: an opacity key (kind "opacity") steps through these values
+    # (opaque → most transparent, then wraps). Persisted live, applied via the KWin script.
+    "opacity_steps": [1.0, 0.85, 0.7, 0.55, 0.4, 0.25],
     "geometry": {"x": 0, "y": 378, "w": 1280, "h": 422},
     "key_size": [74, 64], "wide_size": [110, 64], "space_width": 360,
     "key_settle_ms": 20,
+    # "Big" mode: a size-toggle key (kind "size") flips the keyboard between the
+    # normal geometry above and this larger one, stretching every key to fill the
+    # window (uses the wasted screen space). Toggles live — no relogin.
+    # Sized so keys are ~square (1280/32 units ≈ 80px wide → ~81px rows) and the bottom
+    # edge clears a ~56px KDE panel (256+488 = 744, panel occupies 744-800).
+    "big_geometry": {"x": 0, "y": 256, "w": 1280, "h": 488},
+    "big_key_h": 100,              # key-height floor in big mode (drives the Game Mode strip)
+    "start_big": False,            # come up in big mode
+    # KWin rule group that pins our window in Desktop Mode. Big mode rewrites this
+    # rule's position/size live so the forced geometry follows the toggle. Must match
+    # the UUID the installer writes; "" disables the live geometry change (grid still fills).
+    "kwin_rule_id": "a8a95de3-82aa-4998-87c0-125fb8525143",
+    # Dock on the built-in touchscreen even when an external display shifts the layout.
+    # The window position is offset by this output's origin. "" = auto-detect eDP* (the
+    # internal panel). Only matters with 2+ displays; single-display is unaffected.
+    "internal_output": "",
     # "mirror": true  → the device's keyboard button summons us (via Steam's OSK).
     # "mirror": false → seamless mode: the daemon remaps the hardware keyboard button
     #                   (via InputPlumber) to fire dbus_trigger, which we listen for
@@ -41,6 +60,34 @@ DEFAULT_CONFIG = {
     # mirror is off (or as an extra). Map a controller chord to this combo in Steam
     # Input. [] = off. Needs /dev/input read access (installer's udev rule + 'input').
     "hotkey": [],
+    # Show the keyboard automatically whenever a text field is focused (via AT-SPI
+    # accessibility). Show-only: hiding stays manual (hide key / button). Desktop Mode
+    # only — Game Mode has no accessibility bridge. Works alongside the button trigger.
+    "show_on_focus": False,
+    # Summon the keyboard with a swipe up from the bottom edge of the touchscreen.
+    # Reads the touch device in parallel with the compositor (no grab); show-only.
+    "gesture_summon": False,
+    "gesture_device": "",       # touchscreen evdev path; "" = auto-detect
+    "gesture_debug": False,     # log every stroke to /tmp/handheld-kbd-gesture.log for tuning
+    # Swipe must START in the bottom (1 - gesture_start_frac) of the screen: 0.92 = the
+    # bottom 8% edge only. Raise toward 1.0 to shrink the trigger strip further.
+    "gesture_start_frac": 0.92,
+    "gesture_travel_frac": 0.10,  # and travel up at least this fraction of screen height
+    "gesture_fingers": 2,         # fingers required; 2 = two-finger swipe (won't clash with
+                                  # normal 1-finger scrolling/swiping). Set 1 for one-finger.
+    # Predictive text: a row of tappable suggestions above the keys. Learns what you
+    # type (~/.local/share/handheld-kbd/learned.json). Corpus data is built once by
+    # `handheld-kbd-build-dict`; without it, prediction still works from learning alone.
+    "prediction": True,
+    "suggestion_count": 3,
+    "suggest_height": 44,         # px; the row is taken out of the key area
+    "predict_learn": True,        # remember the words you commit (turn off = corpus only)
+    # Swipe (glide) typing: drag across the letters instead of tapping them. Taps
+    # are unaffected — a drag only counts once it travels far enough AND crosses
+    # enough different letters to be unmistakably not a tap.
+    "swipe": True,
+    "swipe_min_travel": 1.6,      # multiples of key width the finger must travel
+    "swipe_min_keys": 3,          # distinct letters it must cross
     "theme": {
         "window_bg": "#161616", "key_bg": "#333333", "key_fg": "#f5f5f5",
         "key_border": "#0d0d0d", "key_active": "#3daee9",
@@ -128,8 +175,8 @@ def resolve_rows(layout):
         row = []
         for k in jrow:
             kind = k.get("kind", "")
-            if kind in ("locale", "hide"):            # action keys: no keycode
-                dflt = "🌐" if kind == "locale" else "⌵"
+            if kind in ("locale", "hide", "size", "opacity"):    # action keys: no keycode
+                dflt = {"locale": "🌐", "hide": "⌵", "size": "⤢", "opacity": "◐"}.get(kind, "")
                 row.append((k.get("label", dflt), None, kind, "", ""))
                 continue
             name = k.get("key", "")
@@ -155,6 +202,10 @@ button.mod-on {{ background: {t['mod_on_bg']}; color: {t['mod_on_fg']}; font-wei
 button.special {{ background: {t['special_bg']}; color: {t['special_fg']}; }}
 button.hide {{ background: #5a1f1f; color: #ffd9d9; }}
 button.hide:active {{ background: #c0392b; }}
+button.suggest {{ background: {t.get('suggest_bg', '#242424')}; color: {t.get('suggest_fg', '#e8e8e8')};
+                 font-size: 20px; border: 1px solid {t['key_border']}; }}
+button.suggest:active {{ background: {t['key_active']}; }}
+button.suggest-empty {{ background: transparent; border-color: transparent; }}
 window.gm {{ background-color: rgba(0,0,0,0); }}
 .gm-keys {{ background-color: rgba(12,12,12,0.82); }}
 """.encode()
@@ -176,16 +227,22 @@ class OSK(Gtk.Window):
         self.modbtns = []
         self.keybtns = []        # (button, key_name, base_label, base_shifted) for relabeling
         self.locale_btn = None
+        self.size_btn = None
+        self.opacity_btn = None
+        self.big = bool(config.get("start_big", False))
+        self.norm_kh = config["key_size"][1]
+        self.nrows = max(1, len(rows))
         prov = Gtk.CssProvider(); prov.load_from_data(build_css(config["theme"]))
         Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(), prov,
                                                   Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         # Uniform aligned grid: every key snaps to a column grid (column_homogeneous),
         # widths come from per-kind unit spans, rows centred → tidy, even alignment.
         kh = config["key_size"][1]
-        SPAN = {'': 2, 'wide': 3, 'mod': 3, 'space': 8, 'locale': 2, 'hide': 2}
+        SPAN = {'': 2, 'wide': 3, 'mod': 3, 'space': 8, 'locale': 2, 'hide': 2, 'size': 2, 'opacity': 2}
         row_units = [sum(SPAN.get(k[2], 2) for k in row) for row in rows]
         maxu = max(row_units) if row_units else 1
         grid = Gtk.Grid()
+        self.grid = grid
         grid.set_column_homogeneous(True)
         grid.set_halign(Gtk.Align.CENTER)
         grid.set_margin_top(4); grid.set_margin_bottom(4)
@@ -201,6 +258,15 @@ class OSK(Gtk.Window):
                     b.get_style_context().add_class('special')
                     b.connect("clicked", self.on_locale)
                     self.locale_btn = b
+                elif kind == 'size':
+                    b.get_style_context().add_class('special')
+                    b.connect("clicked", self.on_size)
+                    self.size_btn = b
+                elif kind == 'opacity':
+                    b.get_style_context().add_class('special')
+                    b.connect("clicked", self.on_opacity)
+                    self.opacity_btn = b
+                    b.set_label(f"{int(round(float(config.get('opacity', 0.72)) * 100))}%")
                 elif kind == 'hide':
                     b.get_style_context().add_class('hide')
                     b.connect("clicked", lambda *_: self.dismiss())
@@ -213,6 +279,7 @@ class OSK(Gtk.Window):
                     self.keybtns.append((b, name, label, shifted))
                 grid.attach(b, col, ri, sp, 1)
                 col += sp
+        self._init_prediction(rows)
         self.orig_touch_mode = None
         if GAMEMODE:
             # Transparent fullscreen overlay: gamescope fullscreens us, the game shows
@@ -226,8 +293,16 @@ class OSK(Gtk.Window):
             outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
             spacer = Gtk.Box(); spacer.set_vexpand(True)   # transparent filler
             outer.pack_start(spacer, True, True, 0)
+            if self.sugbar is not None:
+                self.sugbar.get_style_context().add_class("gm-keys")
+                outer.pack_start(self.sugbar, False, False, 0)
             outer.pack_end(grid, False, False, 0)
             self.add(outer)
+        elif self.sugbar is not None:
+            box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+            box.pack_start(self.sugbar, False, False, 0)
+            box.pack_start(grid, True, True, 0)
+            self.add(box)
         else:
             self.add(grid)
         self.set_wmclass("handheld-kbd", "handheld-kbd")
@@ -240,6 +315,317 @@ class OSK(Gtk.Window):
         self.set_default_size(g["w"], g["h"])
         self.set_gravity(Gdk.Gravity.SOUTH)
         self.apply_locale(locale)
+        self.apply_size()          # sync grid fill + window/rule geometry to self.big
+        self._init_swipe()
+
+    # ------------------------------------------------------------------
+    # Predictive text
+    # ------------------------------------------------------------------
+    def _init_prediction(self, rows):
+        """Set up the suggestion row. Everything here is best-effort: if the engine
+        or its data is missing the keyboard must still come up as a plain keyboard,
+        so any failure just leaves self.pred None and self.sugbar None."""
+        self.sugbar = None
+        self.pred = None
+        self.sugbtns = []
+        self.suggestions = []
+        self.wordbuf = ""          # the word being typed, as far as we can tell
+        self.prev_word = ""        # last committed word, for next-word prediction
+        # kc -> the character that key produces unshifted (used to follow the typing)
+        self.kc_char = {}
+        # character -> (keycode, needs_shift), used to type a whole word back out
+        self.charmap = {}
+        for row in rows:
+            for (label, kc, kind, shifted, name) in row:
+                if kc is None or not label:
+                    continue
+                if len(label) == 1:
+                    self.kc_char[kc] = label
+                    self.charmap.setdefault(label, (kc, False))
+                    if label.isalpha():
+                        self.charmap.setdefault(label.upper(), (kc, True))
+                if shifted and len(shifted) == 1:
+                    self.charmap.setdefault(shifted, (kc, True))
+        self.charmap.setdefault(" ", (e.KEY_SPACE, False))
+        self.type_settle = self.cfg.get("predict_type_ms", 6) / 1000.0
+
+        if not self.cfg.get("prediction", True):
+            return
+        try:
+            sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+            from handheld_kbd_predict import Predictor, neighbours_from_rows
+            self.pred = Predictor(neighbours=neighbours_from_rows(rows))
+            if not self.pred.ready:
+                print("handheld-kbd: no prediction data — run handheld-kbd-build-dict",
+                      file=sys.stderr)
+        except Exception as ex:
+            print(f"handheld-kbd: prediction disabled ({ex})", file=sys.stderr)
+            self.pred = None
+            return
+
+        n = max(1, int(self.cfg.get("suggestion_count", 3)))
+        bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0, homogeneous=True)
+        bar.set_size_request(-1, int(self.cfg.get("suggest_height", 44)))
+        for i in range(n):
+            b = Gtk.Button(label="")
+            b.set_can_focus(False)
+            b.set_hexpand(True)
+            b.get_style_context().add_class("suggest")
+            b.get_style_context().add_class("suggest-empty")
+            b.connect("clicked", self._on_suggestion, i)
+            bar.pack_start(b, True, True, 0)
+            self.sugbtns.append(b)
+        self.sugbar = bar
+
+    def _emit(self, kc, shift=False, settle=None):
+        """Press and release one key, optionally with Shift held."""
+        s = self.settle if settle is None else settle
+        if shift:
+            self.ui.write(e.EV_KEY, e.KEY_LEFTSHIFT, 1); self.ui.syn(); time.sleep(s)
+        self.ui.write(e.EV_KEY, kc, 1); self.ui.syn(); time.sleep(s)
+        self.ui.write(e.EV_KEY, kc, 0); self.ui.syn(); time.sleep(s)
+        if shift:
+            self.ui.write(e.EV_KEY, e.KEY_LEFTSHIFT, 0); self.ui.syn(); time.sleep(s)
+
+    def _type_text(self, text):
+        """Type a string as real keystrokes. Characters the layout can't produce are
+        skipped rather than mangled."""
+        for ch in text:
+            kc = self.charmap.get(ch)
+            if kc is None:
+                continue
+            self._emit(kc[0], kc[1], self.type_settle)
+
+    def _erase(self, count):
+        for _ in range(count):
+            self._emit(e.KEY_BACKSPACE, False, self.type_settle)
+
+    def _refresh_suggestions(self):
+        if self.pred is None or not self.sugbtns:
+            return
+        try:
+            words = self.pred.suggest(self.wordbuf.lower(), self.prev_word,
+                                      n=len(self.sugbtns))
+        except Exception as ex:
+            print(f"handheld-kbd: suggest failed ({ex})", file=sys.stderr)
+            words = []
+        # Match the capitalisation of what is being typed, so tapping a suggestion
+        # after "Leg" gives "Legion", not "legion".
+        if self.wordbuf[:1].isupper():
+            words = [w.capitalize() for w in words]
+        self._show_suggestions(words)
+
+    def _show_suggestions(self, words):
+        """Paint the suggestion row. Used both by prediction (completions of what
+        you are typing) and by swipe (the runner-up decodings)."""
+        self.suggestions = words
+        for i, b in enumerate(self.sugbtns):
+            w = words[i] if i < len(words) else ""
+            b.set_label(w)
+            ctx = b.get_style_context()
+            (ctx.add_class if not w else ctx.remove_class)("suggest-empty")
+            b.set_sensitive(bool(w))
+
+    def _on_suggestion(self, btn, idx):
+        if idx >= len(self.suggestions):
+            return
+        word = self.suggestions[idx]
+        self._erase(len(self.wordbuf))
+        self._type_text(word + " ")
+        if self.pred is not None and self.cfg.get("predict_learn", True):
+            self.pred.learn(word, self.prev_word)
+            self.pred.maybe_save()
+        self.prev_word = word.lower()
+        self.wordbuf = ""
+        self._refresh_suggestions()
+
+    def _commit_word(self):
+        """The word being typed just ended (space/enter/punctuation)."""
+        w = self.wordbuf.strip("'")
+        if w and self.pred is not None and self.cfg.get("predict_learn", True):
+            self.pred.learn(w, self.prev_word)
+            self.pred.maybe_save()
+        if w:
+            self.prev_word = w.lower()
+        self.wordbuf = ""
+
+    # ---- swipe (glide) typing ----
+    def _init_swipe(self):
+        """Watch raw pointer/touch events so a drag across the keys becomes a word.
+
+        We hook Gdk's event handler rather than connecting to the key buttons: the
+        buttons need to keep seeing their own events so ordinary tapping is
+        completely unaffected, and this way we observe the stream without consuming
+        any of it.
+        """
+        self.swipe = None
+        self._swipe_pts = []
+        self._swipe_active = False
+        self._swipe_is_gesture = False
+        self._swipe_guard = 0.0        # ignore stray clicks just after a swipe
+        self._key_boxes = None         # letter -> (centre, rect), in grid coords
+        self.need_space = False
+        if self.pred is None or not self.cfg.get("swipe", True):
+            return
+        try:
+            from handheld_kbd_swipe import SwipeDecoder
+            self.swipe = SwipeDecoder(self.pred)
+        except Exception as ex:
+            print(f"handheld-kbd: swipe disabled ({ex})", file=sys.stderr)
+            return
+        self.grid.connect("size-allocate", lambda *_: setattr(self, "_key_boxes", None))
+        Gdk.event_handler_set(self._gdk_event, None)
+
+    def _gdk_event(self, ev, *_):
+        """Every event passes through here. It MUST always be forwarded, or the
+        keyboard stops responding entirely."""
+        try:
+            self._swipe_feed(ev)
+        except Exception:
+            pass
+        Gtk.main_do_event(ev)
+
+    def _refresh_key_boxes(self):
+        """Letter-key centres in grid coordinates. Rebuilt after any relayout
+        (big-mode toggle, resize, display change)."""
+        boxes, widths = {}, []
+        for (b, name, base_label, base_shifted) in self.keybtns:
+            label = (base_label or "").lower()
+            if len(label) != 1 or not label.isalpha():
+                continue
+            res = b.translate_coordinates(self.grid, 0, 0)
+            if not res:
+                continue
+            x, y = res[-2], res[-1]
+            a = b.get_allocation()
+            if a.width <= 1 or a.height <= 1:
+                continue
+            boxes[label] = (x + a.width / 2.0, y + a.height / 2.0)
+            widths.append(a.width)
+        self._key_boxes = boxes
+        self._key_w = (sorted(widths)[len(widths) // 2] if widths else 1.0)
+        if boxes and self.swipe is not None:
+            self.swipe.set_keys(boxes, self._key_w)
+
+    def _event_xy(self, ev):
+        """Event position in grid coordinates, or None."""
+        w = Gtk.get_event_widget(ev)
+        if w is None:
+            return None
+        ok = ev.get_coords()
+        if not ok or not ok[0]:
+            return None
+        res = w.translate_coordinates(self.grid, int(ok[1]), int(ok[2]))
+        if not res:
+            return None
+        return (float(res[-2]), float(res[-1]))
+
+    def _swipe_feed(self, ev):
+        if self.swipe is None:
+            return
+        t = ev.type
+        if t in (Gdk.EventType.TOUCH_BEGIN, Gdk.EventType.BUTTON_PRESS):
+            if self._key_boxes is None:
+                self._refresh_key_boxes()
+            pt = self._event_xy(ev)
+            self._swipe_pts = [pt] if pt else []
+            self._swipe_active = bool(pt)
+            self._swipe_is_gesture = False
+        elif t in (Gdk.EventType.TOUCH_UPDATE, Gdk.EventType.MOTION_NOTIFY):
+            if not self._swipe_active:
+                return
+            pt = self._event_xy(ev)
+            if pt is None:
+                return
+            self._swipe_pts.append(pt)
+            if not self._swipe_is_gesture:
+                self._swipe_is_gesture = self._looks_like_gesture()
+        elif t in (Gdk.EventType.TOUCH_END, Gdk.EventType.TOUCH_CANCEL,
+                   Gdk.EventType.BUTTON_RELEASE):
+            if not self._swipe_active:
+                return
+            pt = self._event_xy(ev)
+            if pt:
+                self._swipe_pts.append(pt)
+            was = self._swipe_is_gesture
+            self._swipe_active = False
+            self._swipe_is_gesture = False
+            if was:
+                self._finish_swipe(list(self._swipe_pts))
+            self._swipe_pts = []
+
+    def _looks_like_gesture(self):
+        """A drag only counts as a swipe once it is clearly not a tap: it has to
+        travel a real distance AND pass over several different letters."""
+        pts = self._swipe_pts
+        if len(pts) < 4 or not self._key_boxes:
+            return False
+        kw = getattr(self, "_key_w", 1.0) or 1.0
+        dist = sum(math.dist(pts[i - 1], pts[i]) for i in range(1, len(pts)))
+        if dist < kw * float(self.cfg.get("swipe_min_travel", 1.6)):
+            return False
+        seen, last = [], None
+        for p in pts:
+            best, bd = None, kw * 0.75
+            for ch, c in self._key_boxes.items():
+                d = math.dist(p, c)
+                if d < bd:
+                    best, bd = ch, d
+            if best and best != last:
+                seen.append(best)
+                last = best
+        return len(seen) >= int(self.cfg.get("swipe_min_keys", 3))
+
+    def _finish_swipe(self, pts):
+        """Decode the gesture, type the best word, offer the runners-up."""
+        # Anything already half-typed is a finished word once a swipe starts, so
+        # commit it first — that also gives the decoder the right bigram context.
+        if self.wordbuf:
+            self._commit_word()
+            self.need_space = True
+        try:
+            words = self.swipe.decode(pts, self.prev_word, n=len(self.sugbtns) or 3)
+        except Exception as ex:
+            print(f"handheld-kbd: swipe decode failed ({ex})", file=sys.stderr)
+            return
+        if not words:
+            return
+        best = words[0]
+        if self.need_space:
+            self._type_text(" ")
+        self._type_text(best)
+        self.wordbuf = best            # a suggestion tap now replaces the whole word
+        self.need_space = True
+        self._swipe_guard = time.time() + 0.3
+        self._show_suggestions(words)
+
+    def _track(self, kc, mods):
+        """Follow the typing so we know the current word. We can't see the target
+        application's text, so this is a model of it: anything that could move the
+        caret somewhere we can't predict (arrows, Ctrl-shortcuts, Tab...) resets it
+        rather than risking a wrong-word correction."""
+        if self.pred is None:
+            return
+        self.need_space = False         # the user is driving now
+        ctrlish = any(m in mods for m in (e.KEY_LEFTCTRL, e.KEY_RIGHTCTRL, e.KEY_LEFTALT,
+                                          e.KEY_RIGHTALT, e.KEY_LEFTMETA, e.KEY_RIGHTMETA))
+        ch = self.kc_char.get(kc)
+        if ctrlish:                                   # a shortcut, not typing
+            self.wordbuf = ""; self.prev_word = ""
+        elif kc == e.KEY_BACKSPACE:
+            self.wordbuf = self.wordbuf[:-1]
+        elif kc == e.KEY_SPACE:
+            self._commit_word()
+        elif kc in (e.KEY_ENTER, e.KEY_KPENTER, e.KEY_TAB):
+            self._commit_word(); self.prev_word = ""   # new line/field: no context
+        elif ch and (ch.isalpha() or (ch == "'" and self.wordbuf)):
+            shift = any(m in mods for m in (e.KEY_LEFTSHIFT, e.KEY_RIGHTSHIFT))
+            self.wordbuf += ch.upper() if shift else ch
+        elif ch:                                       # punctuation/digit ends a word
+            self._commit_word()
+        else:                                          # arrows, F-keys, Esc, Del...
+            self.wordbuf = ""; self.prev_word = ""
+        self._refresh_suggestions()
 
     def _set_label(self, button, label, shifted):
         ch = button.get_child()
@@ -261,6 +647,8 @@ class OSK(Gtk.Window):
             self._set_label(self.locale_btn, "🌐" + code.upper(), "")
 
     def on_locale(self, btn):
+        if self._stray_tap():
+            return
         before = active_layout_code()
         try:
             subprocess.run(["qdbus6", "org.kde.keyboard", "/Layouts",
@@ -275,17 +663,191 @@ class OSK(Gtk.Window):
             except Exception: pass
         self.apply_locale(after)
 
+    # ---- Big mode (larger keys that fill the window) ----
+    def on_size(self, btn):
+        if self._stray_tap():
+            return
+        self.big = not self.big
+        self.apply_size()
+        self._persist_big()
+
+    def _persist_big(self):
+        """Write the current mode back to config.json's start_big so it survives both
+        the next relogin AND a mid-session respawn by the swap daemon (button-spam churn
+        otherwise drops us back to normal)."""
+        self._persist("start_big", self.big)
+
+    def _persist(self, key, val):
+        """Merge one key into config.json, preserving the rest; atomic write."""
+        path = os.path.join(CFG_DIR, "config.json")
+        try:
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+            except Exception:
+                data = {}
+            data[key] = val
+            os.makedirs(CFG_DIR, exist_ok=True)
+            tmp = path + ".tmp"
+            with open(tmp, "w") as f:
+                json.dump(data, f, indent=2)
+            os.replace(tmp, path)
+        except Exception as ex:
+            print(f"handheld-kbd: could not persist {key} ({ex})", file=sys.stderr)
+
+    # ---- Transparency cycle ----
+    def on_opacity(self, btn):
+        """Step to the next (more transparent) opacity level, wrapping back to opaque.
+        Persists it and applies live so it survives hide/show and respawns."""
+        if self._stray_tap():
+            return
+        steps = self.cfg.get("opacity_steps", DEFAULT_CONFIG["opacity_steps"])
+        cur = float(self.cfg.get("opacity", 0.72))
+        nxt = next((s for s in steps if s < cur - 1e-6), steps[0])  # first below cur, else wrap
+        self.cfg["opacity"] = nxt
+        self._persist("opacity", nxt)
+        self._apply_opacity(nxt)
+        if self.opacity_btn:
+            self.opacity_btn.set_label(f"{int(round(nxt * 100))}%")
+
+    def _apply_opacity(self, val):
+        """Our opacity is compositor-controlled (a Wayland client can't set its own),
+        so patch the persistent handheld-kbd-opacity KWin script's `var OP` and reload
+        it — reloading re-runs setOp on every window, applying the new value live and
+        keeping it for future shows/respawns."""
+        opscript = os.path.expanduser(
+            "~/.local/share/kwin/scripts/handheld-kbd-opacity/contents/code/main.js")
+        try:
+            with open(opscript) as f:
+                lines = f.read().splitlines()
+            for i, l in enumerate(lines):
+                if l.strip().startswith("var OP ="):
+                    lines[i] = f"var OP = {val};"
+                    break
+            with open(opscript, "w") as f:
+                f.write("\n".join(lines) + "\n")
+        except Exception as ex:
+            print(f"handheld-kbd: could not patch opacity script ({ex})", file=sys.stderr)
+        S = "org.kde.kwin.Scripting."
+        for args in (["unloadScript", "handheld-kbd-opacity"],
+                     ["loadScript", opscript, "handheld-kbd-opacity"],
+                     ["start"]):
+            try:
+                subprocess.run(["qdbus6", "org.kde.KWin", "/Scripting", S + args[0]] + args[1:],
+                               check=False, timeout=3)
+            except Exception:
+                pass
+
+    def apply_size(self):
+        """Toggle between the normal centred layout and 'big' mode, where every key
+        stretches to fill the whole window (both axes) so no screen space is wasted."""
+        big = self.big
+        # Grid fill behaviour: big → keys expand to fill; normal → tidy centred cluster.
+        self.grid.set_halign(Gtk.Align.FILL if big else Gtk.Align.CENTER)
+        self.grid.set_valign(Gtk.Align.FILL)
+        self.grid.set_row_homogeneous(big)
+        # In Desktop big mode the resized window + row_homogeneous drive key height, so
+        # keep the size_request floor at the normal height (a taller floor would exceed
+        # the per-row allocation and distort the grid). Game Mode has no window resize,
+        # so there big_key_h is what actually grows the docked strip.
+        kh = self.cfg.get("big_key_h", 100) if (big and GAMEMODE) else self.norm_kh
+        g = (self.cfg.get("big_geometry", DEFAULT_CONFIG["big_geometry"])
+             if big else self.cfg["geometry"])
+        if not GAMEMODE:
+            # The suggestion row eats into a window whose size is FORCED by the KWin
+            # rule. Left alone, full-height keys push the window's minimum past that
+            # forced height, and an over-constrained Wayland window keeps its input
+            # region but stops painting — it takes taps while being invisible. So the
+            # keys shrink to fit whatever the suggestion row leaves behind.
+            # apply_size() runs before the window is realised, where the row still
+            # measures as ~0 — so trust the configured height (plus its margins) and
+            # only prefer the measured value once it is real and larger.
+            bar = 0
+            if self.sugbar is not None:
+                bar = max(int(self.cfg.get("suggest_height", 44)) + 8,
+                          self.sugbar.get_preferred_height()[0])
+            fit = (g["h"] - bar - 8) // self.nrows        # 8 = grid top+bottom margins
+            kh = max(24, min(kh, fit))
+        for child in self.grid.get_children():
+            child.set_vexpand(big)
+            child.set_valign(Gtk.Align.FILL)
+            child.set_size_request(-1, kh)
+        if self.size_btn:
+            self._set_label(self.size_btn, "⤡" if big else "⤢", "")
+        # Window geometry. Game Mode is a fullscreen gamescope overlay (keys docked at
+        # the bottom) — the taller key rows above already grow the strip, no resize/rule.
+        if GAMEMODE:
+            return
+        ox, oy = self._panel_origin()        # anchor to the internal touchscreen, not an external
+        rect = {"x": g["x"] + ox, "y": g["y"] + oy, "w": g["w"], "h": g["h"]}
+        self.resize(rect["w"], rect["h"])
+        self.move(rect["x"], rect["y"])
+        self._apply_kwin_geometry(rect)
+
+    def _panel_origin(self):
+        """Logical origin (x,y) of the INTERNAL panel (eDP*), so we dock on the built-in
+        touchscreen even when an external display shifts the coordinate space (an external
+        at 0,0 would otherwise steal position 0,378). Returns (0,0) on a single display or
+        any failure — i.e. the original behaviour."""
+        want = (self.cfg.get("internal_output", "") or "").lower()
+        try:
+            data = json.loads(subprocess.check_output(
+                ["kscreen-doctor", "-j"], text=True, timeout=3))
+            outs = [o for o in data.get("outputs", []) if o.get("enabled")]
+            if len(outs) < 2:
+                return (0, 0)                # single display → no offset needed
+            def internal(o):
+                n = (o.get("name") or "").lower()
+                return n == want if want else n.startswith("edp")
+            m = next((o for o in outs if internal(o)), None)
+            if m is None:
+                return (0, 0)
+            pos = m.get("pos") or {}
+            return (int(pos.get("x", 0)), int(pos.get("y", 0)))
+        except Exception:
+            return (0, 0)
+
+    def _apply_kwin_geometry(self, g):
+        """Rewrite our KWin window-rule's forced position/size so it follows the toggle
+        and the internal-panel anchor; without this the Force rule would snap the window
+        back. Skips the write when the rect is unchanged (re-anchoring on every show would
+        otherwise reconfigure KWin needlessly and flicker)."""
+        rid = self.cfg.get("kwin_rule_id", "")
+        if not rid:
+            return
+        rect = (g["x"], g["y"], g["w"], g["h"])
+        if rect == getattr(self, "_last_rect", None):
+            return
+        self._last_rect = rect
+        try:
+            for key, val in (("position", f"{g['x']},{g['y']}"), ("size", f"{g['w']},{g['h']}")):
+                subprocess.run(["kwriteconfig6", "--file", "kwinrulesrc", "--group", rid,
+                                "--key", key, val], check=False, timeout=3)
+            subprocess.run(["qdbus6", "org.kde.KWin", "/KWin", "reconfigure"],
+                           check=False, timeout=3)
+        except Exception as ex:
+            print(f"handheld-kbd: kwin geometry update failed ({ex})", file=sys.stderr)
+
     def _refresh_mods(self):
         for b, k in self.modbtns:
             ctx = b.get_style_context()
             (ctx.add_class if k in self.mods else ctx.remove_class)('mod-on')
 
     def on_mod(self, btn, kc):
+        if self._stray_tap():
+            return
         if kc in self.mods: del self.mods[kc]
         else: self.mods[kc] = True
         self._refresh_mods()
 
+    def _stray_tap(self):
+        """True just after a swipe ends: GTK may still deliver a click for the key the
+        finger lifted over, which is not something the user meant to press."""
+        return time.time() < getattr(self, "_swipe_guard", 0.0)
+
     def on_key(self, btn, kc):
+        if self._stray_tap():
+            return
         s = self.settle
         mods = list(self.mods)
         for m in mods: self.ui.write(e.EV_KEY, m, 1)
@@ -295,10 +857,13 @@ class OSK(Gtk.Window):
         for m in reversed(mods): self.ui.write(e.EV_KEY, m, 0)
         if mods: self.ui.syn()
         self.mods.clear(); self._refresh_mods()
+        self._track(kc, mods)
 
     def dismiss(self):
         """Hide button: hide now and tell the mirror daemon to stay hidden until the
         next time the device's keyboard button is pressed (so it doesn't pop right back)."""
+        if self._stray_tap():
+            return
         try: open("/tmp/handheld-kbd.suppress", "w").write("1")
         except Exception: pass
         try: open("/tmp/handheld-kbd.vis", "w").write("0")
@@ -381,6 +946,166 @@ def setup_dbus_trigger(config, toggle):
                          None, None, Gio.DBusSignalFlags.NONE, on_sig)
     _dbus_keepalive.append(bus)              # prevent GC of the subscribed connection
     print(f"handheld-kbd: dbus trigger listening for {ev}", file=sys.stderr)
+
+
+_atspi_keepalive = []   # keep the AT-SPI listener alive or it's GC'd
+
+
+def setup_focus_trigger(config, show):
+    """show_on_focus: pop the keyboard whenever an editable text field gains focus,
+    detected via AT-SPI accessibility events. Show-only — hiding stays manual. Desktop
+    Mode only (Game Mode / gamescope has no accessibility bridge). Runs on the same
+    GLib main loop as GTK, so no extra thread."""
+    if not config.get("show_on_focus", False) or GAMEMODE:
+        return
+    # AT-SPI often can't auto-locate the running a11y bus from a service env; point it there.
+    if not os.environ.get("AT_SPI_BUS_ADDRESS"):
+        try:
+            addr = subprocess.check_output(
+                ["qdbus6", "org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus.GetAddress"],
+                text=True, timeout=3).strip()
+            if addr:
+                os.environ["AT_SPI_BUS_ADDRESS"] = addr
+        except Exception:
+            pass
+    try:
+        gi.require_version("Atspi", "2.0")
+        from gi.repository import Atspi
+    except Exception as ex:
+        print(f"handheld-kbd: show_on_focus unavailable ({ex})", file=sys.stderr)
+        return
+    edit_roles = {Atspi.Role.ENTRY, Atspi.Role.TEXT, Atspi.Role.PASSWORD_TEXT,
+                  Atspi.Role.DOCUMENT_TEXT, Atspi.Role.TERMINAL, Atspi.Role.DOCUMENT_FRAME}
+
+    def on_focus(ev):
+        try:
+            if ev.detail1 != 1:                    # 1 = gained focus
+                return
+            acc = ev.source
+            if acc.get_state_set().contains(Atspi.StateType.EDITABLE) or acc.get_role() in edit_roles:
+                show()
+        except Exception:
+            pass
+    try:
+        lis = Atspi.EventListener.new(on_focus)
+        lis.register("object:state-changed:focused")
+        _atspi_keepalive.append(lis)
+        print("handheld-kbd: show_on_focus listening (AT-SPI editable focus)", file=sys.stderr)
+    except Exception as ex:
+        print(f"handheld-kbd: show_on_focus register failed ({ex})", file=sys.stderr)
+
+
+def setup_gesture(config, show):
+    """gesture_summon: a two-finger (gesture_fingers) swipe up from the bottom edge of
+    the touchscreen shows the keyboard. Two fingers avoids clashing with normal
+    one-finger scrolling/swiping. Reads the touch device in parallel with the
+    compositor (no exclusive grab), on the GLib loop. Show-only. Desktop Mode only."""
+    if not config.get("gesture_summon", False) or GAMEMODE:
+        return
+    try:
+        from evdev import InputDevice, list_devices
+    except Exception:
+        return
+    dev = None
+    try:
+        path = config.get("gesture_device", "") or ""
+        if path:
+            dev = InputDevice(path)
+        else:                                   # auto-detect: a real touchSCREEN
+            # Match multitouch + BTN_TOUCH, but require INPUT_PROP_DIRECT (touchscreen)
+            # and skip INPUT_PROP_POINTER (touchpads such as a Magic Trackpad also report
+            # BTN_TOUCH + ABS_MT_POSITION_X and would otherwise hijack the gesture).
+            fallback = None
+            for p in sorted(list_devices()):
+                try:
+                    d = InputDevice(p)
+                    caps = d.capabilities()
+                    if e.BTN_TOUCH not in caps.get(e.EV_KEY, []) or \
+                       e.ABS_MT_POSITION_X not in [c for c, _ in caps.get(e.EV_ABS, [])]:
+                        continue
+                    props = d.input_props()
+                    if e.INPUT_PROP_POINTER in props:       # touchpad → not a touchscreen
+                        continue
+                    if e.INPUT_PROP_DIRECT in props:        # definite touchscreen → take it
+                        dev = d
+                        break
+                    if fallback is None:                    # ambiguous; last resort
+                        fallback = d
+                except Exception:
+                    continue
+            if dev is None:
+                dev = fallback
+    except Exception as ex:
+        print(f"handheld-kbd: gesture device open failed ({ex})", file=sys.stderr)
+        return
+    if dev is None:
+        print("handheld-kbd: gesture_summon on but no touchscreen found", file=sys.stderr)
+        return
+    absinfo = dict(dev.capabilities().get(e.EV_ABS, []))
+    yaxis = absinfo.get(e.ABS_MT_POSITION_Y) or absinfo.get(e.ABS_Y)
+    ymax = yaxis.max if yaxis else 1
+    START_FRAC = float(config.get("gesture_start_frac", 0.92))   # start in bottom (1-frac) edge
+    TRAVEL_FRAC = float(config.get("gesture_travel_frac", 0.10))  # travel up ≥ this frac of height
+    MAX_MS = 1200                                                 # within 1.2s
+    dbg = config.get("gesture_debug", False)
+    FINGERS = int(config.get("gesture_fingers", 2))   # require this many fingers; 2 avoids
+                                                       # clashing with 1-finger scroll/swipe
+    # Track each contact via the MT-B slot protocol (ABS_MT_SLOT + ABS_MT_TRACKING_ID).
+    # A gesture spans first-finger-down .. last-finger-up; fire show() only if it peaked at
+    # EXACTLY FINGERS contacts (so 2- and 3-finger gestures stay distinct) and they all
+    # started in the bottom edge and moved up.
+    strokes = {}                                       # slot -> {"y0", "y"}
+    st = {"cur": 0, "active": 0, "peak": 0, "t0": 0.0}
+
+    def evaluate():
+        dt = time.time() - st["t0"] if st["t0"] else 999.0
+        oky = [s for s in strokes.values()
+               if s["y0"] is not None and s["y"] is not None
+               and s["y0"] > START_FRAC * ymax and (s["y0"] - s["y"]) > TRAVEL_FRAC * ymax]
+        # EXACT finger count so counts stay distinct (a 3-finger swipe must NOT trigger a
+        # 2-finger binding). peak == FINGERS + all of them did the bottom-up swipe.
+        fired = st["peak"] == FINGERS and len(oky) >= FINGERS and dt < MAX_MS / 1000.0
+        if dbg:
+            try:
+                with open("/tmp/handheld-kbd-gesture.log", "a") as f:
+                    f.write(f"gesture peak={st['peak']} up_ok={len(oky)} need={FINGERS} "
+                            f"dt={dt:.2f} fired={fired} ymax={ymax} "
+                            f"strokes={[(s['y0'], s['y']) for s in strokes.values()]}\n")
+            except Exception:
+                pass
+        if fired:
+            show()
+
+    def on_touch(fd, cond):
+        try:
+            for ev in dev.read():
+                if ev.type != e.EV_ABS:
+                    continue
+                if ev.code == e.ABS_MT_SLOT:
+                    st["cur"] = ev.value
+                elif ev.code == e.ABS_MT_TRACKING_ID:
+                    if ev.value >= 0:                  # a new contact begins
+                        if st["active"] == 0:          # first finger → start a fresh gesture
+                            strokes.clear(); st["peak"] = 0; st["t0"] = time.time()
+                        st["active"] += 1
+                        st["peak"] = max(st["peak"], st["active"])
+                        strokes[st["cur"]] = {"y0": None, "y": None}
+                    else:                              # a contact lifts
+                        st["active"] = max(0, st["active"] - 1)
+                        if st["active"] == 0:          # all fingers up → judge the gesture
+                            evaluate()
+                elif ev.code in (e.ABS_MT_POSITION_Y, e.ABS_Y):
+                    s = strokes.get(st["cur"])
+                    if s is None:                      # position before tracking_id (rare)
+                        s = {"y0": None, "y": None}; strokes[st["cur"]] = s
+                    if s["y0"] is None:
+                        s["y0"] = ev.value
+                    s["y"] = ev.value
+        except OSError:
+            return False                               # device gone → drop the watch
+        return True
+    GLib.io_add_watch(dev.fd, GLib.IO_IN, on_touch)
+    print(f"handheld-kbd: gesture_summon listening on {dev.name}", file=sys.stderr)
 
 
 def setup_hotkey(config, toggle):
@@ -467,10 +1192,29 @@ def main():
     rows, allkeys = resolve_rows(layout)
     if not allkeys:
         rows, allkeys = resolve_rows(DEFAULT_LAYOUT)
+    # Prediction types whole words back out, so these must exist on the uinput device
+    # even if the user's layout happens not to include them.
+    allkeys = sorted(set(allkeys) | {e.KEY_BACKSPACE, e.KEY_SPACE, e.KEY_LEFTSHIFT})
     locale = resolve_locale(config)
 
     w = OSK(config, rows, allkeys, locale)
-    w.connect("destroy", Gtk.main_quit)
+
+    def _flush_learned():
+        """Persist the personal vocabulary now (normal saves are debounced)."""
+        if getattr(w, "pred", None) is not None:
+            w.pred.maybe_save(force=True)
+
+    def _on_destroy(*_):
+        _flush_learned()
+        Gtk.main_quit()
+
+    def _on_term(*_):
+        _flush_learned()
+        Gtk.main_quit()
+        return False
+
+    w.connect("destroy", _on_destroy)
+    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, _on_term, None)
     open("/tmp/handheld-kbd.pid", "w").write(str(os.getpid()))
     VIS = "/tmp/handheld-kbd.vis"
 
@@ -479,6 +1223,7 @@ def main():
         except Exception: pass
 
     def _show(*_):
+        w.apply_size()                    # re-anchor to the internal panel (handles display hotplug)
         w.show_all()
         if GAMEMODE:                      # set overlay atoms once gamescope has mapped us
             GLib.timeout_add(250, w.gm_show)
@@ -497,8 +1242,17 @@ def main():
         except Exception: pass
         (_hide if cur == "1" else _show)()
 
+    def _focus_show():
+        cur = "0"
+        try: cur = open(VIS).read().strip()
+        except Exception: pass
+        if cur != "1":                    # show-only, idempotent (no auto-hide)
+            _show()
+
     setup_dbus_trigger(config, _toggle)   # seamless hardware-button trigger (InputPlumber)
     setup_hotkey(config, _toggle)         # optional evdev hotkey (attached kbd / Steam Input chord)
+    setup_focus_trigger(config, _focus_show)  # optional: auto-show when a text field is focused
+    setup_gesture(config, _focus_show)        # optional: swipe up from bottom edge to summon
 
     _setvis("1" if os.environ.get("HANDHELD_KBD_SHOW") == "1" else "0")
     if os.environ.get("HANDHELD_KBD_SHOW") == "1":

--- a/bin/handheld_kbd_predict.py
+++ b/bin/handheld_kbd_predict.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Predictive-text engine for Better Handheld Keyboard.
+
+Pure-Python, offline, no daemons. Three sources of evidence, combined as a linear
+interpolation of probabilities (see score()):
+
+  corpus unigram   how common the word is in general
+  corpus bigram    how likely the word is right after the previous word
+  personal unigram what YOU type
+  personal bigram  what YOU type after a given word
+
+Personal evidence carries half the total mass, so the keyboard adapts to your own
+vocabulary within a handful of uses instead of being permanently outvoted by a
+web-scale corpus (your friends' names, "gamescope", "Legion", ...).
+
+Corpus data lives in ~/.local/share/handheld-kbd/ as two compact text files built
+by `handheld-kbd-build-dict`. Personal data is learned.json in the same directory,
+saved lazily (debounced) so we never block a keystroke on disk I/O.
+
+The module degrades rather than fails: with no corpus files it still works purely
+from what you've typed, and with no data at all suggest() just returns [].
+"""
+import os, json, math, time, bisect, tempfile
+
+DATA_DIR = os.path.expanduser("~/.local/share/handheld-kbd")
+
+# Interpolation weights. Personal sources get half the mass on purpose (see above);
+# within each half, the context-aware (bigram) source outweighs the context-free one.
+W_UNI, W_BI, W_PUNI, W_PBI = 0.18, 0.32, 0.18, 0.32
+
+# A correction (the word is not a prefix-extension of what was typed) is multiplied
+# by this, so a correction only wins when it is *far* more likely than the literal
+# typing. Adjacent-key slips are treated as much more plausible than random ones.
+PENALTY_ADJACENT = 0.06     # 'helli' -> 'hello'  (i and o are neighbours)
+PENALTY_FAR = 0.004         # unrelated substitution / insertion / deletion
+
+# Extending a corrected stem assumes both a typo and the unseen remainder, so it is
+# damped relative to offering the correction itself.
+W_CORRECTED_STEM = 0.25
+# What you literally typed, when it is a real word, gets a slight edge over longer
+# completions of it — you are more often finished than mid-word.
+W_EXACT = 1.6
+
+MAX_MEMO = 4000             # bounded prefix->candidates cache
+SAVE_DEBOUNCE_S = 20.0      # coalesce learned.json writes
+
+
+def _atomic_write(path, text):
+    d = os.path.dirname(path) or "."
+    os.makedirs(d, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=d)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        try: os.unlink(tmp)
+        except Exception: pass
+        raise
+
+
+class Predictor:
+    def __init__(self, data_dir=DATA_DIR, neighbours=None, max_words=0):
+        self.dir = data_dir
+        self.words = []          # sorted, lowercase
+        self.counts = []         # parallel to words
+        self.uni = {}            # word -> count
+        self.uni_total = 1
+        self.bi = {}             # prev -> {word: count}
+        self.bi_total = {}       # prev -> sum of its counts
+        self.pu = {}             # personal unigram
+        self.pu_total = 0
+        self.pbi = {}            # personal bigram
+        self.pbi_total = {}
+        self.neigh = neighbours or {}   # char -> set(adjacent chars), from the real layout
+        self._memo = {}
+        self._dirty = False
+        self._last_save = 0.0
+        self._load_corpus(max_words)
+        self._load_personal()
+
+    # ---------- loading ----------
+    def _load_corpus(self, max_words):
+        try:
+            with open(os.path.join(self.dir, "unigrams.txt")) as f:
+                for line in f:
+                    w, _, c = line.partition("\t")
+                    if not c:
+                        continue
+                    try: n = int(c)
+                    except ValueError: continue
+                    self.uni[w] = n
+                    if max_words and len(self.uni) >= max_words:
+                        break
+        except Exception:
+            pass
+        self.words = sorted(self.uni)
+        self.counts = [self.uni[w] for w in self.words]
+        self.uni_total = sum(self.counts) or 1
+        try:
+            with open(os.path.join(self.dir, "bigrams.txt")) as f:
+                for line in f:
+                    parts = line.rstrip("\n").split("\t")
+                    if len(parts) != 3:
+                        continue
+                    a, b, c = parts
+                    try: n = int(c)
+                    except ValueError: continue
+                    self.bi.setdefault(a, {})[b] = n
+        except Exception:
+            pass
+        self.bi_total = {a: (sum(d.values()) or 1) for a, d in self.bi.items()}
+
+    def _load_personal(self):
+        try:
+            with open(os.path.join(self.dir, "learned.json")) as f:
+                d = json.load(f)
+            self.pu = {k: int(v) for k, v in (d.get("uni") or {}).items()}
+            self.pbi = {a: {k: int(v) for k, v in m.items()}
+                        for a, m in (d.get("bi") or {}).items()}
+        except Exception:
+            self.pu, self.pbi = {}, {}
+        self.pu_total = sum(self.pu.values())
+        self.pbi_total = {a: (sum(m.values()) or 1) for a, m in self.pbi.items()}
+
+    @property
+    def ready(self):
+        return bool(self.words) or bool(self.pu)
+
+    # ---------- learning ----------
+    def learn(self, word, prev=None):
+        """Record that the user actually committed `word` (after `prev`)."""
+        w = (word or "").strip().lower()
+        if not w or not w[0].isalpha() or len(w) > 40:
+            return
+        self.pu[w] = self.pu.get(w, 0) + 1
+        self.pu_total += 1
+        p = (prev or "").strip().lower()
+        if p:
+            m = self.pbi.setdefault(p, {})
+            m[w] = m.get(w, 0) + 1
+            self.pbi_total[p] = self.pbi_total.get(p, 0) + 1
+        self._memo.pop(w[:1], None)          # its ranking may have changed
+        self._dirty = True
+
+    def maybe_save(self, force=False):
+        """Debounced persist. Safe to call on every keystroke."""
+        if not self._dirty:
+            return
+        now = time.time()
+        if not force and now - self._last_save < SAVE_DEBOUNCE_S:
+            return
+        try:
+            _atomic_write(os.path.join(self.dir, "learned.json"),
+                          json.dumps({"uni": self.pu, "bi": self.pbi}))
+            self._dirty = False
+            self._last_save = now
+        except Exception:
+            pass
+
+    # ---------- probability ----------
+    def _p(self, w, prev):
+        """Interpolated P(w | prev). Missing sources drop out and the remaining
+        weights are renormalised, so a word the corpus has never seen is still
+        scored fairly on personal evidence alone."""
+        parts, tot = 0.0, 0.0
+        c = self.uni.get(w)
+        if self.uni_total > 1:
+            tot += W_UNI
+            if c: parts += W_UNI * (c / self.uni_total)
+        if prev:
+            d = self.bi.get(prev)
+            if d:
+                tot += W_BI
+                n = d.get(w)
+                if n: parts += W_BI * (n / self.bi_total[prev])
+        if self.pu_total:
+            tot += W_PUNI
+            n = self.pu.get(w)
+            if n: parts += W_PUNI * (n / self.pu_total)
+            m = self.pbi.get(prev or "")
+            if m:
+                tot += W_PBI
+                n = m.get(w)
+                if n: parts += W_PBI * (n / self.pbi_total[prev])
+        if tot <= 0:
+            return 0.0
+        return parts / tot
+
+    # ---------- candidate generation ----------
+    def _completions(self, prefix, limit=60):
+        """Indices of corpus words starting with `prefix`, best-first."""
+        if not prefix:
+            return []
+        hit = self._memo.get(prefix)
+        if hit is not None:
+            return hit
+        i = bisect.bisect_left(self.words, prefix)
+        idx = []
+        n = len(self.words)
+        while i < n and self.words[i].startswith(prefix):
+            idx.append(i)
+            i += 1
+        idx.sort(key=lambda k: -self.counts[k])
+        idx = idx[:limit]
+        if len(self._memo) > MAX_MEMO:
+            self._memo.clear()
+        self._memo[prefix] = idx
+        return idx
+
+    def _adjacent(self, a, b):
+        return b in self.neigh.get(a, ())
+
+    def _edits(self, w):
+        """Keyboard-aware edit-distance-1 variants, each tagged with how plausible
+        the slip is. Substitutions of neighbouring keys (and doubled/dropped letters,
+        which are the other common touch-typing slip) count as 'adjacent'."""
+        out = {}
+        letters = "abcdefghijklmnopqrstuvwxyz'"
+        for i in range(len(w)):
+            # deletion: user typed an extra character
+            cand = w[:i] + w[i + 1:]
+            if cand:
+                dup = i > 0 and w[i] == w[i - 1]
+                out.setdefault(cand, PENALTY_ADJACENT if dup else PENALTY_FAR)
+            # substitution
+            for c in letters:
+                if c == w[i]:
+                    continue
+                cand = w[:i] + c + w[i + 1:]
+                pen = PENALTY_ADJACENT if self._adjacent(w[i], c) else PENALTY_FAR
+                if out.get(cand, 0) < pen:
+                    out[cand] = pen
+            # transposition of neighbouring characters
+            if i + 1 < len(w):
+                cand = w[:i] + w[i + 1] + w[i] + w[i + 2:]
+                if out.get(cand, 0) < PENALTY_ADJACENT:
+                    out[cand] = PENALTY_ADJACENT
+        # insertion: user dropped a character
+        for i in range(len(w) + 1):
+            for c in letters:
+                cand = w[:i] + c + w[i:]
+                prevc = w[i - 1] if i > 0 else ""
+                pen = PENALTY_ADJACENT if (prevc and prevc == c) else PENALTY_FAR
+                if out.get(cand, 0) < pen:
+                    out[cand] = pen
+        out.pop(w, None)
+        return out
+
+    # ---------- the public call ----------
+    def suggest(self, prefix, prev=None, n=3, corrections=True):
+        """Ranked suggestions for the word currently being typed.
+
+        prefix "" -> next-word prediction from `prev` alone.
+        Returns a list of words, best first, never containing duplicates.
+        """
+        prefix = (prefix or "").lower()
+        prev = (prev or "").lower() or None
+        scored = {}
+
+        if not prefix:
+            # Pure next-word prediction: everything the corpus/personal bigrams
+            # have ever seen after `prev`.
+            if not prev:
+                return []
+            pool = set()
+            pool.update((self.bi.get(prev) or {}).keys())
+            pool.update((self.pbi.get(prev) or {}).keys())
+            for w in pool:
+                p = self._p(w, prev)
+                if p > 0:
+                    scored[w] = p
+        else:
+            for i in self._completions(prefix):
+                w = self.words[i]
+                p = self._p(w, prev)
+                if p > 0:
+                    scored[w] = p
+            # personal words are not in the corpus list, so scan them too (small)
+            for w in self.pu:
+                if w.startswith(prefix):
+                    p = self._p(w, prev)
+                    if p > 0:
+                        scored[w] = max(scored.get(w, 0.0), p)
+            if corrections and len(prefix) >= 2:
+                for cand, pen in self._edits(prefix).items():
+                    # The correction itself — only ever offered if it is a real word,
+                    # otherwise we would suggest the typo's neighbours as words.
+                    if cand in self.uni or cand in self.pu:
+                        v = self._p(cand, prev) * pen
+                        if v > scored.get(cand, 0.0):
+                            scored[cand] = v
+                    # ...and the correction used as a stem. Correcting *and* guessing
+                    # the rest is a compound assumption, so it is penalised again.
+                    for i in self._completions(cand, limit=6):
+                        w = self.words[i]
+                        v = self._p(w, prev) * W_CORRECTED_STEM * pen
+                        if v > scored.get(w, 0.0):
+                            scored[w] = v
+
+        # The literal typing always stays reachable: if what you typed is itself a
+        # known word, it is never allowed to fall off the list entirely, and it gets
+        # a small edge over longer completions of itself ("i" should beat "in").
+        if prefix and (prefix in self.uni or prefix in self.pu):
+            lit = self._p(prefix, prev) * W_EXACT
+            if lit > scored.get(prefix, 0.0):
+                scored[prefix] = lit
+
+        best = sorted(scored.items(), key=lambda kv: -kv[1])[:n]
+        return [w for w, _ in best]
+
+
+# ---- neighbour map helper -------------------------------------------------
+def neighbours_from_rows(rows):
+    """Build char -> adjacent chars from the OSK's own resolved layout rows, so
+    typo correction matches the keyboard actually on screen (staggered QWERTY,
+    or whatever else the user has configured).
+
+    `rows` is the OSK's resolved structure: [[(label, kc, kind, shifted, name)...]]
+    Only single-character alphabetic labels take part.
+    """
+    grid = []
+    for row in rows:
+        cur = []
+        for item in row:
+            label = (item[0] or "").lower()
+            cur.append(label if len(label) == 1 and label.isalpha() else None)
+        grid.append(cur)
+    neigh = {}
+    for r, row in enumerate(grid):
+        for c, ch in enumerate(row):
+            if not ch:
+                continue
+            s = neigh.setdefault(ch, set())
+            for dr in (-1, 0, 1):
+                rr = r + dr
+                if not (0 <= rr < len(grid)):
+                    continue
+                # rows are horizontally staggered, so on the rows above/below look
+                # one column wider on each side
+                span = (-1, 0, 1) if dr == 0 else (-1, 0, 1)
+                for dc in span:
+                    cc = c + dc
+                    if dr == 0 and dc == 0:
+                        continue
+                    if 0 <= cc < len(grid[rr]) and grid[rr][cc]:
+                        s.add(grid[rr][cc])
+    return neigh
+
+
+if __name__ == "__main__":
+    import sys
+    p = Predictor()
+    print(f"corpus words={len(p.words)} bigram heads={len(p.bi)} "
+          f"personal={len(p.pu)} ready={p.ready}")
+    args = sys.argv[1:]
+    if args:
+        prev = args[0] if len(args) > 1 else None
+        pre = args[-1]
+        print(f"prev={prev!r} prefix={pre!r} -> {p.suggest(pre, prev, n=5)}")

--- a/bin/handheld_kbd_swipe.py
+++ b/bin/handheld_kbd_swipe.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Glide/swipe typing decoder for Better Handheld Keyboard.
+
+Given the path a finger traced across the keys, work out which word was meant.
+This is the SHARK²/ShapeWriter approach (Kristensson & Zhai, UIST 2004), reduced
+to what runs comfortably in pure Python on a handheld:
+
+  1. Candidates come from an index keyed on (first letter, last letter). The ends
+     of a swipe are the parts the user aims at deliberately, so they are by far the
+     most reliable signal — and it turns a 80k-word scan into a few hundred.
+  2. A path-length prior throws out words whose ideal gesture is much longer or
+     shorter than what was actually drawn. This is nearly free and prunes hard.
+  3. Survivors are scored coarsely (10 sample points), and only the best of those
+     are scored finely (32 points) on two channels:
+        location — how close the drawn path sits to the word's ideal path
+        shape    — how similar they are after normalising away position and scale
+     Location alone confuses words on the same keys; shape alone confuses words
+     that trace the same figure elsewhere on the keyboard. Together they don't.
+  4. The language model (the same Predictor the suggestion row uses, including
+     everything it has learned about your vocabulary) breaks the remaining ties.
+
+Returns a ranked list, so the caller can type the best word and offer the rest.
+"""
+import math
+
+N_COARSE = 10          # sample points for the cheap first pass
+N_FINE = 24            # sample points for the real comparison
+COARSE_KEEP = 30       # candidates promoted to fine scoring
+
+LEN_LO, LEN_HI = 0.5, 2.0     # allowed ideal/drawn path-length ratio
+
+W_SHAPE = 0.5          # weight of the shape channel relative to location
+W_END = 0.8            # weight of the endpoint channel (see below)
+W_LM = 0.9             # how much the language model may move a geometric verdict
+MIN_LEN = 2            # words shorter than this are tapped, not swiped
+
+
+def _resample(pts, n):
+    """Uniformly re-sample a polyline to exactly n points by arc length."""
+    if not pts:
+        return []
+    if len(pts) == 1:
+        return [pts[0]] * n
+    acc = [0.0]
+    for i in range(1, len(pts)):
+        acc.append(acc[-1] + math.dist(pts[i - 1], pts[i]))
+    total = acc[-1]
+    if total <= 1e-9:
+        return [pts[0]] * n
+    out, step, j = [], total / (n - 1), 0
+    for i in range(n):
+        target = i * step
+        while j < len(acc) - 2 and acc[j + 1] < target:
+            j += 1
+        seg = acc[j + 1] - acc[j]
+        t = 0.0 if seg <= 1e-9 else (target - acc[j]) / seg
+        ax, ay = pts[j]
+        bx, by = pts[j + 1]
+        out.append((ax + (bx - ax) * t, ay + (by - ay) * t))
+    return out
+
+
+def _smooth(pts, window=5):
+    """Moving average over the raw touch samples.
+
+    Finger jitter is small per sample but it accumulates: measured against a clean
+    polyline, raw samples of a swipe can be 30-75% longer than the gesture actually
+    drawn, which wrecks both the length prior and the shape comparison. Smoothing
+    first makes the drawn path comparable to a word's ideal path.
+    """
+    n = len(pts)
+    if n <= window:
+        return list(pts)
+    half = window // 2
+    out = []
+    for i in range(n):
+        lo, hi = max(0, i - half), min(n, i + half + 1)
+        seg = pts[lo:hi]
+        k = len(seg)
+        out.append((sum(p[0] for p in seg) / k, sum(p[1] for p in seg) / k))
+    return out
+
+
+def _polyline_len(pts):
+    return sum(math.dist(pts[i - 1], pts[i]) for i in range(1, len(pts)))
+
+
+def _chamfer(a, b):
+    """Symmetric mean nearest-neighbour distance between two point sets.
+
+    Preferred over comparing samples index-by-index, because that assumes both
+    paths were traversed at the same rate. Real swipes cut corners and slow down
+    at direction changes, which shifts the index correspondence and punishes the
+    correct word. Nearest-point matching doesn't care how the path was timed.
+    """
+    s1 = sum(min(math.dist(p, q) for q in b) for p in a) / len(a)
+    s2 = sum(min(math.dist(q, p) for p in a) for q in b) / len(b)
+    return 0.5 * (s1 + s2)
+
+
+def _normalise(pts):
+    """Translate to centroid and scale to unit RMS radius, so two paths can be
+    compared on shape alone."""
+    n = len(pts)
+    cx = sum(p[0] for p in pts) / n
+    cy = sum(p[1] for p in pts) / n
+    cen = [(p[0] - cx, p[1] - cy) for p in pts]
+    r = math.sqrt(sum(x * x + y * y for x, y in cen) / n)
+    if r < 1e-9:
+        return cen
+    return [(x / r, y / r) for x, y in cen]
+
+
+class SwipeDecoder:
+    def __init__(self, predictor):
+        self.pred = predictor
+        self.centers = {}      # char -> (x, y) in grid coordinates
+        self.key_w = 1.0
+        self._buckets = {}     # (first, last) -> [word]
+        self._vocab_key = None
+
+    # ---- setup -----------------------------------------------------------
+    def set_keys(self, centers, key_w):
+        """Tell the decoder where the letter keys currently are."""
+        self.centers = dict(centers)
+        self.key_w = max(1.0, float(key_w))
+        self._rebuild_index()
+
+    def _rebuild_index(self):
+        """Index the vocabulary by (first, last) letter. Rebuilt only when the
+        vocabulary or the available keys actually change."""
+        vocab_key = (len(getattr(self.pred, "words", ())),
+                     len(getattr(self.pred, "pu", ())),
+                     "".join(sorted(self.centers)))
+        if vocab_key == self._vocab_key:
+            return
+        self._vocab_key = vocab_key
+        keys = set(self.centers)
+        buckets = {}
+        words = list(getattr(self.pred, "words", ()))
+        words += [w for w in getattr(self.pred, "pu", {}) if w not in self.pred.uni]
+        for w in words:
+            if len(w) < MIN_LEN:
+                continue
+            if not keys.issuperset(w):
+                continue
+            buckets.setdefault((w[0], w[-1]), []).append(w)
+        self._buckets = buckets
+
+    @property
+    def ready(self):
+        return bool(self._buckets)
+
+    # ---- decoding --------------------------------------------------------
+    def _near_keys(self, pt, radius_mult=0.95):
+        """Letter keys whose centre is within radius of a point, nearest first."""
+        r = self.key_w * radius_mult
+        out = []
+        for ch, c in self.centers.items():
+            d = math.dist(pt, c)
+            if d <= r:
+                out.append((d, ch))
+        out.sort()
+        return [ch for _, ch in out[:4]]
+
+    def _ideal(self, word):
+        return [self.centers[c] for c in word]
+
+    def decode(self, path, prev_word=None, n=3):
+        """Rank the words that the drawn `path` could be. Best first."""
+        if len(path) < 3 or not self._buckets:
+            return []
+        path = _smooth(path)
+        drawn_len = _polyline_len(path)
+        if drawn_len < self.key_w * 0.8:
+            return []                      # too short to be a gesture
+
+        starts = self._near_keys(path[0]) or []
+        ends = self._near_keys(path[-1]) or []
+        if not starts or not ends:
+            return []
+
+        cands = []
+        for s in starts:
+            for e2 in ends:
+                cands.extend(self._buckets.get((s, e2), ()))
+        if not cands:
+            return []
+
+        user_coarse = _resample(path, N_COARSE)
+
+        # --- pass 1: length prior, then coarse location cost ---------------
+        scored = []
+        for w in cands:
+            ideal = self._ideal(w)
+            ilen = _polyline_len(ideal)
+            # a straight two-key word has a short ideal path; guard against /0
+            ratio = (ilen + self.key_w) / (drawn_len + self.key_w)
+            if ratio < LEN_LO or ratio > LEN_HI:
+                continue
+            ic = _resample(ideal, N_COARSE)
+            cost = sum(math.dist(a, b) for a, b in zip(user_coarse, ic))
+            scored.append((cost / (N_COARSE * self.key_w), w))
+        if not scored:
+            return []
+        scored.sort()
+        finalists = [w for _, w in scored[:COARSE_KEEP]]
+
+        # --- pass 2: fine location + shape, then the language model ---------
+        user_fine = _resample(path, N_FINE)
+        user_norm = _normalise(user_fine)
+        out = []
+        for w in finalists:
+            ideal_fine = _resample(self._ideal(w), N_FINE)
+            loc = _chamfer(user_fine, ideal_fine) / self.key_w
+            ideal_norm = _normalise(ideal_fine)
+            shp = sum(math.dist(a, b) for a, b in zip(user_norm, ideal_norm)) / N_FINE
+            # Endpoint channel: where a swipe starts and stops is aimed at
+            # deliberately, unlike the middle, which is just travel. Without this,
+            # a word that ends one key early ("gel" for "hello") scores almost as
+            # well as the real one.
+            ends = (math.dist(user_fine[0], ideal_fine[0]) +
+                    math.dist(user_fine[-1], ideal_fine[-1])) / (2.0 * self.key_w)
+            geo = loc + W_SHAPE * shp + W_END * ends
+            try:
+                p = self.pred._p(w, prev_word)
+            except Exception:
+                p = 0.0
+            lm = math.log10(p) if p > 0 else -12.0
+            # lm is about -2 (very common) to -12 (unknown); map to a bounded bonus
+            out.append((geo - W_LM * ((lm + 12.0) / 10.0), w))
+        out.sort()
+        return [w for _, w in out[:n]]

--- a/config/config.json
+++ b/config/config.json
@@ -1,12 +1,22 @@
 {
   "layout": "full",
+  "locale": "auto",
   "opacity": 0.72,
+  "opacity_steps": [1.0, 0.85, 0.7, 0.55, 0.4, 0.25],
   "geometry": {
     "x": 0,
     "y": 378,
     "w": 1280,
     "h": 422
   },
+  "big_geometry": {
+    "x": 0,
+    "y": 256,
+    "w": 1280,
+    "h": 488
+  },
+  "big_key_h": 100,
+  "start_big": false,
   "key_size": [
     74,
     64
@@ -17,6 +27,14 @@
   ],
   "space_width": 360,
   "key_settle_ms": 20,
+  "prediction": true,
+  "suggestion_count": 3,
+  "suggest_height": 44,
+  "predict_learn": true,
+  "swipe": true,
+  "show_on_focus": false,
+  "gesture_summon": false,
+  "gesture_fingers": 2,
   "game_overlay": true,
   "per_game_overlay": {},
   "theme": {
@@ -32,7 +50,6 @@
     "special_fg": "#bbccdd",
     "shifted_fg": "#7fb0ff"
   },
-  "locale": "auto",
   "hotkey": [],
   "mirror": true,
   "dbus_trigger": "ui_select"

--- a/config/layouts/compact.json
+++ b/config/layouts/compact.json
@@ -73,6 +73,14 @@
         "kind": "wide"
       },
       {
+        "label": "◐",
+        "kind": "opacity"
+      },
+      {
+        "label": "⤢",
+        "kind": "size"
+      },
+      {
         "label": "⌵",
         "kind": "hide"
       }

--- a/config/layouts/full.json
+++ b/config/layouts/full.json
@@ -55,6 +55,14 @@
         "key": "KEY_F12"
       },
       {
+        "label": "◐",
+        "kind": "opacity"
+      },
+      {
+        "label": "⤢",
+        "kind": "size"
+      },
+      {
         "label": "⌵",
         "kind": "hide"
       }

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,14 @@ install -m755 "$HERE/bin/handheld-kbd-swap.sh"   "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-relogin"   "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-ip-remap"  "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-recover"   "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-build-dict" "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-focus-probe" "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-resume.sh"  "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-resume-watch.sh" "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-resume-watch.py" "$BIN/"
+# imported by handheld-kbd.py (prediction + swipe engines), not run directly
+install -m644 "$HERE/bin/handheld_kbd_predict.py" "$BIN/"
+install -m644 "$HERE/bin/handheld_kbd_swipe.py"   "$BIN/"
 
 # --- config (never clobber the user's edits) ---
 FRESH=0
@@ -115,7 +123,8 @@ install -m644 "$HERE/kwin/handheld-kbd-opacity/contents/code/main.js" "$KWIN/con
 # --- autostart (templates carry __BIN__; substitute this user's real path) ---
 sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd.desktop"      > "$AUTO/handheld-kbd.desktop"
 sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd-swap.desktop" > "$AUTO/handheld-kbd-swap.desktop"
-chmod 644 "$AUTO/handheld-kbd.desktop" "$AUTO/handheld-kbd-swap.desktop"
+sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd-resume.desktop"   > "$AUTO/handheld-kbd-resume.desktop"
+chmod 644 "$AUTO/handheld-kbd.desktop" "$AUTO/handheld-kbd-swap.desktop" "$AUTO/handheld-kbd-resume.desktop"
 
 # --- KWin window rule (pins the keyboard: on top, no focus-steal, bottom-docked) ---
 if command -v kwriteconfig6 >/dev/null 2>&1; then
@@ -167,4 +176,8 @@ echo "   • Log out and back in once (activates autostart + permissions)."
 echo "   • Then press your device's keyboard button — this keyboard comes up instead."
 echo "   • Edit ~/.config/handheld-kbd/config.json for opacity, layout, theme, optional hotkey."
 echo "   • No keyboard at all afterwards? Run:  handheld-kbd-recover"
+echo
+say "Predictive text works from what you type straight away. For corpus-backed"
+say "suggestions from the first keypress, build the dictionary once:"
+echo "     handheld-kbd-build-dict"
 [ "${PRIV_OK:-0}" = 1 ] || warn "Permission step didn't complete — typing won't work until it does."


### PR DESCRIPTION
The version running on my Legion Go 2 had drifted well ahead of the repo. This brings it back, rebased on top of today's Legion Go 1 fixes rather than over them.

## Features

- **Predictive text** — tappable suggestion row above the keys (`handheld_kbd_predict.py`). Learns the words you commit; `handheld-kbd-build-dict` adds corpus frequencies so it's useful before it knows you. Tapping a suggestion erases the partial word and types the full one as real keystrokes, so it works in any app. Degrades to a plain keyboard if the engine or data is missing.
- **Big mode** — a `size` key (⤢) toggles `geometry` ↔ `big_geometry`, stretching keys to fill the window and rewriting the KWin rule live. No relogin.
- **Opacity cycling** — an `opacity` key (◐) steps through `opacity_steps` and persists it.
- **Swipe typing** — drag across letters to type a word; only counts once it travels far enough and crosses enough distinct keys, so taps are unaffected.
- **Two optional summons** — two-finger swipe up from the bottom edge, and AT-SPI show-on-focus. Both off by default.
- **Resume handling** — `handheld-kbd-resume-watch.py` re-inits on logind `PrepareForSleep`, fixing a stale trigger or uinput handle after sleep.
- **Fullscreen and focus** — the KWin script keeps the keyboard above fullscreen windows (temporary `keepBelow` on the fullscreen window, restored after) and re-asserts focus on the window you were typing into.

## Today's fixes are preserved

Both `handheld-kbd.py` and `handheld-kbd-swap.sh` are newer on the device than in the repo, so they were merged rather than copied:

- `_mark_proven()` re-applied to the device's `_show()`
- the daemon's `hide_steam_wanted` gating, `write_opscript`/`load_opscript` split and remap-failure fallback re-applied around the device's richer KWin script — the Steam-OSK rule is now injected via `$STEAM_RULE` so it can be omitted until the keyboard proves it appears
- `handheld-kbd-ip-remap` and `handheld-kbd-recover` kept at the repo (v1.0.1) versions, which are newer than the device's

## Privacy

Prediction data is generated on device and git-ignored: `unigrams.txt`, `bigrams.txt`, `learned.json`, `raw/`. The repo ships the builder, not the data — nothing about what I've typed is in this diff. Staged payloads audited: 17 files, code and config only.

## Testing

Python and shell syntax checked; KWin script generation verified with and without the Steam rule; JSON validated. Runtime verification is the next step — this needs installing on the Go 2 from the v1.1.0 release and confirming prediction, big mode and the button trigger all still behave.