### PR TITLE
A move key: redock the keyboard between edges and displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
+## v1.0.3 — A move key
+
+### Added
+
+- **Move key** (`kind: "move"`, ✥). Steps the keyboard through docking slots instead of
+  leaving it pinned wherever the KWin rule put it:
+  - slot 0 is the configured `geometry`, anchored to the internal panel — unchanged
+    default, so nothing moves unless you ask it to
+  - then one slot per (display, edge) pair — `bottom`, `top`, `middle` by default via
+    `dock_edges` — internal panel first, centred horizontally on that display
+  - the slot list is resolved live from `kscreen-doctor`, so plugging in a monitor adds
+    its slots without a restart, and unplugging wraps the selection back into range
+  - it also forces the KWin rule to be rewritten even when the rect looks unchanged,
+    which is the way out of a position that has got stuck
+  - the chosen slot persists to `config.json` as `dock`, and the key's label shows the
+    edge — plus the display name once there's more than one to choose from
+
+### Changed
+
+- Display enumeration moved into one `_outputs()` helper (name, position, current-mode
+  size, internal flag), which `_panel_origin()` now uses too.
+
 ## v1.0.2 — Predictive text and a bigger keyboard
 
 Everything from v1.0.1 stays: the trigger detection fix, the fail-visible KWin rule, the

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ So I built the keyboard I wanted instead. Here's what it does differently:
   Toggles live, no relogin.
 - **Cycle transparency from the keyboard.** The ◐ key steps through
   `opacity_steps` instead of making you edit JSON to see what's underneath.
+- **Move it.** The ✥ key steps the keyboard between docking spots: bottom, top,
+  middle, and the same on every attached display. Handy when the bottom edge is
+  where the thing you're typing into lives, when an external monitor has left the
+  keyboard on the wrong screen, or when a forced position gets stuck — the key
+  re-asserts the window rule either way.
 - **Swipe typing.** Drag across the letters instead of tapping them. Taps are
   unaffected — a drag only counts once it's unmistakably not one.
 - **Optional summon gestures.** Two-finger swipe up from the bottom edge

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -48,6 +48,13 @@ DEFAULT_CONFIG = {
     # The window position is offset by this output's origin. "" = auto-detect eDP* (the
     # internal panel). Only matters with 2+ displays; single-display is unaffected.
     "internal_output": "",
+    # Where the keyboard sits. A move key (kind "move") steps through the slots: 0 is the
+    # configured geometry above, then one slot per (display, edge) pair with the internal
+    # panel first. Use it when the keyboard shouldn't be pinned to the bottom, when an
+    # external monitor has left it docked to the wrong screen, or when a forced position
+    # gets stuck — the key rewrites the KWin rule even if the rect looks unchanged.
+    "dock": 0,
+    "dock_edges": ["bottom", "top", "middle"],
     # "mirror": true  → the device's keyboard button summons us (via Steam's OSK).
     # "mirror": false → seamless mode: the daemon remaps the hardware keyboard button
     #                   (via InputPlumber) to fire dbus_trigger, which we listen for
@@ -175,8 +182,9 @@ def resolve_rows(layout):
         row = []
         for k in jrow:
             kind = k.get("kind", "")
-            if kind in ("locale", "hide", "size", "opacity"):    # action keys: no keycode
-                dflt = {"locale": "🌐", "hide": "⌵", "size": "⤢", "opacity": "◐"}.get(kind, "")
+            if kind in ("locale", "hide", "size", "opacity", "move"):   # action keys: no keycode
+                dflt = {"locale": "🌐", "hide": "⌵", "size": "⤢",
+                        "opacity": "◐", "move": "✥"}.get(kind, "")
                 row.append((k.get("label", dflt), None, kind, "", ""))
                 continue
             name = k.get("key", "")
@@ -229,7 +237,10 @@ class OSK(Gtk.Window):
         self.locale_btn = None
         self.size_btn = None
         self.opacity_btn = None
+        self.move_btn = None
         self.big = bool(config.get("start_big", False))
+        # Which docking slot we're in; 0 = exactly the configured geometry (see _dock_slots).
+        self.dock = max(0, int(config.get("dock", 0)))
         self.norm_kh = config["key_size"][1]
         self.nrows = max(1, len(rows))
         prov = Gtk.CssProvider(); prov.load_from_data(build_css(config["theme"]))
@@ -267,6 +278,10 @@ class OSK(Gtk.Window):
                     b.connect("clicked", self.on_opacity)
                     self.opacity_btn = b
                     b.set_label(f"{int(round(float(config.get('opacity', 0.72)) * 100))}%")
+                elif kind == 'move':
+                    b.get_style_context().add_class('special')
+                    b.connect("clicked", self.on_move)
+                    self.move_btn = b
                 elif kind == 'hide':
                     b.get_style_context().add_class('hide')
                     b.connect("clicked", lambda *_: self.dismiss())
@@ -778,34 +793,115 @@ class OSK(Gtk.Window):
         # the bottom) — the taller key rows above already grow the strip, no resize/rule.
         if GAMEMODE:
             return
-        ox, oy = self._panel_origin()        # anchor to the internal touchscreen, not an external
-        rect = {"x": g["x"] + ox, "y": g["y"] + oy, "w": g["w"], "h": g["h"]}
+        rect = self._slot_rect(g)            # configured spot, or wherever the move key put us
         self.resize(rect["w"], rect["h"])
         self.move(rect["x"], rect["y"])
         self._apply_kwin_geometry(rect)
+        if self.move_btn:
+            self._set_label(self.move_btn, self._move_label(), "")
+
+    def _outputs(self):
+        """Enabled displays as [{name, x, y, w, h, internal}], the internal panel first.
+
+        Empty list if kscreen-doctor isn't there or says nothing useful, in which case
+        callers fall back to the configured geometry as-is."""
+        want = (self.cfg.get("internal_output", "") or "").lower()
+        outs = []
+        try:
+            data = json.loads(subprocess.check_output(
+                ["kscreen-doctor", "-j"], text=True, timeout=3))
+            for o in data.get("outputs", []):
+                if not o.get("enabled"):
+                    continue
+                pos = o.get("pos") or {}
+                # size comes from the current mode; fall back to the reported size
+                mode = next((m for m in (o.get("modes") or [])
+                             if m.get("id") == o.get("currentModeId")), {})
+                sz = mode.get("size") or o.get("size") or {}
+                name = o.get("name") or ""
+                if not sz.get("width") or not sz.get("height"):
+                    continue
+                outs.append({
+                    "name": name,
+                    "x": int(pos.get("x", 0)), "y": int(pos.get("y", 0)),
+                    "w": int(sz["width"]), "h": int(sz["height"]),
+                    "internal": (name.lower() == want if want
+                                 else name.lower().startswith("edp")),
+                })
+        except Exception:
+            return []
+        outs.sort(key=lambda o: (not o["internal"], o["x"], o["y"]))
+        return outs
 
     def _panel_origin(self):
         """Logical origin (x,y) of the INTERNAL panel (eDP*), so we dock on the built-in
         touchscreen even when an external display shifts the coordinate space (an external
         at 0,0 would otherwise steal position 0,378). Returns (0,0) on a single display or
         any failure — i.e. the original behaviour."""
-        want = (self.cfg.get("internal_output", "") or "").lower()
-        try:
-            data = json.loads(subprocess.check_output(
-                ["kscreen-doctor", "-j"], text=True, timeout=3))
-            outs = [o for o in data.get("outputs", []) if o.get("enabled")]
-            if len(outs) < 2:
-                return (0, 0)                # single display → no offset needed
-            def internal(o):
-                n = (o.get("name") or "").lower()
-                return n == want if want else n.startswith("edp")
-            m = next((o for o in outs if internal(o)), None)
-            if m is None:
-                return (0, 0)
-            pos = m.get("pos") or {}
-            return (int(pos.get("x", 0)), int(pos.get("y", 0)))
-        except Exception:
-            return (0, 0)
+        outs = self._outputs()
+        if len(outs) < 2:
+            return (0, 0)                    # single display → no offset needed
+        m = next((o for o in outs if o["internal"]), None)
+        return (m["x"], m["y"]) if m else (0, 0)
+
+    def _dock_slots(self):
+        """Places the move key can put the keyboard, in cycle order.
+
+        Slot 0 is always the configured geometry anchored to the internal panel — i.e.
+        exactly where the keyboard has always sat, so the default is unchanged. After
+        that comes one slot per (display, edge) pair, internal display first, which is
+        what makes the keyboard reachable when it's docked to the wrong screen or an
+        external monitor has shifted the coordinate space under it.
+
+        Returns [(label, edge, output_or_None)]; resolved live so hotplugging a display
+        changes the cycle without a restart."""
+        slots = [("dock", "configured", None)]
+        for o in self._outputs():
+            for edge in self.cfg.get("dock_edges", DEFAULT_CONFIG["dock_edges"]):
+                slots.append((o["name"] or ("internal" if o["internal"] else "external"),
+                              edge, o))
+        return slots
+
+    def _slot_rect(self, g):
+        """Window rect for the current dock slot, given the configured size `g`."""
+        slots = self._dock_slots()
+        self.dock %= len(slots)              # a display went away → wrap into range
+        label, edge, out = slots[self.dock]
+        if out is None:                      # slot 0: configured position, internal anchor
+            ox, oy = self._panel_origin()
+            return {"x": g["x"] + ox, "y": g["y"] + oy, "w": g["w"], "h": g["h"]}
+        w = min(g["w"], out["w"])
+        h = min(g["h"], out["h"])
+        x = out["x"] + (out["w"] - w) // 2   # centred horizontally on that display
+        y = out["y"] + (out["h"] - h) if edge == "bottom" else out["y"]
+        if edge == "middle":
+            y = out["y"] + (out["h"] - h) // 2
+        return {"x": x, "y": y, "w": w, "h": h}
+
+    # ---- Move key (which screen / which edge the keyboard docks to) ----
+    def on_move(self, btn):
+        """Step to the next docking slot. Also the way out of a wedged position: it
+        forces the KWin rule to be rewritten even when the rect hasn't changed."""
+        if self._stray_tap():
+            return
+        slots = self._dock_slots()
+        self.dock = (self.dock + 1) % len(slots)
+        self._persist("dock", self.dock)
+        self._last_rect = None               # force the rule write even if unchanged
+        self.apply_size()
+
+    def _move_label(self):
+        """Short label for the move key: the edge, plus the display when there's a choice."""
+        slots = self._dock_slots()
+        if not slots:
+            return "✥"
+        name, edge, out = slots[self.dock % len(slots)]
+        if out is None:
+            return "✥"
+        arrow = {"bottom": "✥↓", "top": "✥↑", "middle": "✥•"}.get(edge, "✥")
+        multi = len([s for s in slots if s[2] is not None]) > len(
+            self.cfg.get("dock_edges", DEFAULT_CONFIG["dock_edges"]))
+        return f"{arrow} {name}" if multi else arrow
 
     def _apply_kwin_geometry(self, g):
         """Rewrite our KWin window-rule's forced position/size so it follows the toggle

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,14 @@
   "layout": "full",
   "locale": "auto",
   "opacity": 0.72,
-  "opacity_steps": [1.0, 0.85, 0.7, 0.55, 0.4, 0.25],
+  "opacity_steps": [
+    1.0,
+    0.85,
+    0.7,
+    0.55,
+    0.4,
+    0.25
+  ],
   "geometry": {
     "x": 0,
     "y": 378,
@@ -17,6 +24,12 @@
   },
   "big_key_h": 100,
   "start_big": false,
+  "dock": 0,
+  "dock_edges": [
+    "bottom",
+    "top",
+    "middle"
+  ],
   "key_size": [
     74,
     64

--- a/config/layouts/compact.json
+++ b/config/layouts/compact.json
@@ -81,6 +81,10 @@
         "kind": "size"
       },
       {
+        "label": "✥",
+        "kind": "move"
+      },
+      {
         "label": "⌵",
         "kind": "hide"
       }

--- a/config/layouts/full.json
+++ b/config/layouts/full.json
@@ -63,6 +63,10 @@
         "kind": "size"
       },
       {
+        "label": "✥",
+        "kind": "move"
+      },
+      {
         "label": "⌵",
         "kind": "hide"
       }


### PR DESCRIPTION
The keyboard sits wherever the forced KWin rule puts it, which is wrong in three situations: the bottom edge is where the field you're typing into lives, an external monitor has shifted the coordinate space and left the keyboard docked to the wrong screen, or a forced position has got stuck.

## The key

`kind: "move"` (default label ✥, added to both layouts next to ◐ and ⤢). Each press steps to the next docking slot:

- **slot 0** — the configured `geometry`, anchored to the internal panel. Identical to today's behaviour, so nothing moves for anyone who doesn't press the key.
- **then one slot per (display, edge)** — `dock_edges` defaults to `["bottom", "top", "middle"]` — internal panel first, centred horizontally on that display, sized `min(configured, display)`.

Slots are resolved live from `kscreen-doctor` on every press, so plugging a monitor in extends the cycle with no restart, and unplugging wraps the stored index back into range rather than dumping the window off-screen.

Pressing it also clears `_last_rect`, forcing the KWin rule to be rewritten even when the rect looks unchanged — that's the escape hatch for a wedged position.

The selection persists to `config.json` as `dock`, and the key relabels itself with the edge (`✥↓`, `✥↑`, `✥•`), plus the display name once there's more than one display to choose between.

## Refactor

Display enumeration is now a single `_outputs()` helper returning name, position, current-mode size and an internal flag; `_panel_origin()` uses it instead of parsing `kscreen-doctor` itself.

## Testing

Slot arithmetic exercised directly against both a single-display Go 2 (1920×1200) and a two-display layout:

| slot | single display | with a 2560×1440 external at x=1920 |
|---|---|---|
| 0 | `0,378` (unchanged) | `0,378` |
| 1 bottom | `320,778` | `320,778` |
| 2 top | `320,0` | `320,0` |
| 4 | — | `2560,1018` on DP-1 |

Slot 7 wraps to slot 0. Python syntax and JSON validated; needs an on-device pass for the KWin rule rewrite and the relabelling.