### PR TITLE
Fit any panel resolution, not just 1280x800

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ The heading must be `## v<version> — <title>` and the version must match the t
   - the chosen slot persists to `config.json` as `dock`, and the key's label shows the
     edge — plus the display name once there's more than one to choose from
 
+### Fixed
+
+- **Works on any panel resolution.** Every rect — including the configured one — is now
+  clamped to the display it's going onto: sizes shrink to fit, then the position is pulled
+  back inside. The shipped geometry is sized for a 1280×800 Steam Deck, so on a 1280×720
+  panel it used to hang 78px off the bottom, and a partly-off-screen Wayland window still
+  takes taps while not being fully visible. No-op where it already fits, so the Deck and
+  the Legion Go 2 are unchanged.
+- **The installer sizes for the panel it's on.** On a fresh install, `geometry` and
+  `big_geometry` are derived from the internal display (full width, 55% / 64% height,
+  bottom-docked) instead of assuming 1280×800, and the forced KWin rule is written from
+  that geometry rather than a hardcoded `0,378 1280,422`. Existing configs are left alone.
+
 ### Changed
 
 - Display enumeration moved into one `_outputs()` helper (name, position, current-mode

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -862,21 +862,40 @@ class OSK(Gtk.Window):
                               edge, o))
         return slots
 
+    def _clamp_rect(self, rect, out):
+        """Keep a rect inside `out`, whatever the resolution.
+
+        The shipped geometry is sized for a 1280x800 panel, so on anything shorter or
+        narrower the configured rect would hang off the edge — and a Wayland window that
+        is partly outside its output still takes taps while not being fully visible. Sizes
+        shrink to fit first, then the position is pulled back inside. No-op when it
+        already fits, so the usual case is untouched."""
+        if not out:
+            return rect
+        w = max(160, min(rect["w"], out["w"]))
+        h = max(80, min(rect["h"], out["h"]))
+        x = min(max(rect["x"], out["x"]), out["x"] + out["w"] - w)
+        y = min(max(rect["y"], out["y"]), out["y"] + out["h"] - h)
+        return {"x": x, "y": y, "w": w, "h": h}
+
     def _slot_rect(self, g):
         """Window rect for the current dock slot, given the configured size `g`."""
         slots = self._dock_slots()
         self.dock %= len(slots)              # a display went away → wrap into range
         label, edge, out = slots[self.dock]
         if out is None:                      # slot 0: configured position, internal anchor
+            outs = self._outputs()
+            anchor = next((o for o in outs if o["internal"]), outs[0] if outs else None)
             ox, oy = self._panel_origin()
-            return {"x": g["x"] + ox, "y": g["y"] + oy, "w": g["w"], "h": g["h"]}
+            return self._clamp_rect(
+                {"x": g["x"] + ox, "y": g["y"] + oy, "w": g["w"], "h": g["h"]}, anchor)
         w = min(g["w"], out["w"])
         h = min(g["h"], out["h"])
         x = out["x"] + (out["w"] - w) // 2   # centred horizontally on that display
         y = out["y"] + (out["h"] - h) if edge == "bottom" else out["y"]
         if edge == "middle":
             y = out["y"] + (out["h"] - h) // 2
-        return {"x": x, "y": y, "w": w, "h": h}
+        return self._clamp_rect({"x": x, "y": y, "w": w, "h": h}, out)
 
     # ---- Move key (which screen / which edge the keyboard docks to) ----
     def on_move(self, btn):

--- a/install.sh
+++ b/install.sh
@@ -116,6 +116,47 @@ PY
   fi
 fi
 
+# --- size the keyboard for THIS panel (fresh installs only) ---
+# The shipped geometry suits a 1280x800 Steam Deck. On any other panel it would be the
+# wrong width and, on a shorter screen, hang off the bottom. Derive it from the internal
+# display instead: full width, 55% height (capped), docked to the bottom edge. The
+# keyboard clamps at runtime too, so this only makes the first launch look right.
+PANEL_W=""; PANEL_H=""
+if [ "$FRESH" = 1 ] && command -v kscreen-doctor >/dev/null 2>&1; then
+  eval "$(python3 - <<'PY' 2>/dev/null
+import json, subprocess
+try:
+    data = json.loads(subprocess.check_output(["kscreen-doctor", "-j"], text=True, timeout=5))
+except Exception:
+    raise SystemExit(0)
+outs = [o for o in data.get("outputs", []) if o.get("enabled")]
+if not outs:
+    raise SystemExit(0)
+def size(o):
+    mode = next((m for m in (o.get("modes") or []) if m.get("id") == o.get("currentModeId")), {})
+    s = mode.get("size") or o.get("size") or {}
+    return s.get("width"), s.get("height")
+internal = next((o for o in outs if (o.get("name") or "").lower().startswith("edp")), outs[0])
+w, h = size(internal)
+if w and h:
+    print(f'PANEL_W={int(w)}; PANEL_H={int(h)}')
+PY
+)"
+fi
+if [ -n "$PANEL_W" ] && [ -n "$PANEL_H" ]; then
+  say "Sizing for this panel: ${PANEL_W}x${PANEL_H}"
+  python3 - "$CFG/config.json" "$PANEL_W" "$PANEL_H" <<'PY'
+import json, sys
+p, W, H = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+d = json.load(open(p))
+h = min(int(H * 0.55), max(240, int(H * 0.55)))          # 55% of the panel
+big = min(int(H * 0.64), H)
+d["geometry"] = {"x": 0, "y": H - h, "w": W, "h": h}
+d["big_geometry"] = {"x": 0, "y": H - big, "w": W, "h": big}
+json.dump(d, open(p, "w"), indent=2)
+PY
+fi
+
 # --- KWin translucency script ---
 install -m644 "$HERE/kwin/handheld-kbd-opacity/metadata.json" "$KWIN/metadata.json"
 install -m644 "$HERE/kwin/handheld-kbd-opacity/contents/code/main.js" "$KWIN/contents/code/main.js"
@@ -136,8 +177,21 @@ if command -v kwriteconfig6 >/dev/null 2>&1; then
   "${K[@]}" noborder true;         "${K[@]}" noborderrule 2
   "${K[@]}" skiptaskbar true;      "${K[@]}" skiptaskbarrule 2
   "${K[@]}" skippager true;        "${K[@]}" skippagerrule 2
-  "${K[@]}" position "0,378";      "${K[@]}" positionrule 2
-  "${K[@]}" size "1280,422";       "${K[@]}" sizerule 2
+  # The forced position/size must match the geometry above, or the rule fights the window
+  # on first show. The keyboard rewrites both live (move key, big mode), so this is just
+  # the starting point — but on a panel that isn't 1280x800 the old hardcoded values put
+  # the window partly off-screen until something moved it.
+  RULE_GEOM="$(python3 -c '
+import json, sys
+try:
+    g = json.load(open(sys.argv[1]))["geometry"]
+    print("%d,%d %d,%d" % (g["x"], g["y"], g["w"], g["h"]))
+except Exception:
+    print("0,378 1280,422")
+' "$CFG/config.json" 2>/dev/null || echo "0,378 1280,422")"
+  RULE_POS="${RULE_GEOM%% *}"; RULE_SIZE="${RULE_GEOM##* }"
+  "${K[@]}" position "$RULE_POS";  "${K[@]}" positionrule 2
+  "${K[@]}" size "$RULE_SIZE";     "${K[@]}" sizerule 2
   cur="$(kreadconfig6 --file kwinrulesrc --group General --key rules 2>/dev/null)"
   case ",$cur," in *",$RULE_UUID,"*) : ;; *)
     new="${cur:+$cur,}$RULE_UUID"


### PR DESCRIPTION
Follow-up to #5. The move key's computed slots were already resolution-derived, but two things were not.

## 1. Slot 0 used raw configured coordinates

The shipped `geometry` is `0,378 1280x422` — correct for a 1280×800 Deck, where `378 + 422 = 800` exactly. On anything shorter it hangs off the bottom, and a Wayland window partly outside its output still takes taps while not being fully visible.

Every rect now goes through `_clamp_rect()`: sizes shrink to fit the target display, then the position is pulled back inside. It's a no-op where the rect already fits, so the Deck and Legion Go 2 are byte-identical.

| panel | slot 0 before | slot 0 after | on-screen |
|---|---|---|---|
| 1280×800 (Deck) | `0,378 1280x422` | unchanged | yes |
| 1920×1200 (Go 2) | `0,378 1280x422` | unchanged | yes |
| 1280×720 | `0,378` — 78px off the bottom | `0,298` | yes |
| 800×480 | `0,378 1280x422` — off two edges | `0,58 800x422` | yes |
| 3840×2160 | `0,378 1280x422` | unchanged | yes |

## 2. The installer hardcoded the same numbers

`geometry`, `big_geometry` and the forced KWin rule all assumed 1280×800. On a fresh install they're now derived from the internal panel — full width, 55% height (64% for big mode), bottom-docked — and the rule is written from whatever geometry ended up in the config:

| panel | derived geometry |
|---|---|
| 1280×800 | `0,360 1280x440` |
| 1920×1200 | `0,540 1920x660` |
| 1280×720 | `0,324 1280x396` |
| 800×480 | `0,216 800x264` |

Existing configs are never touched — this only affects first install.

Between the two, the keyboard is on-screen and correctly docked whatever the panel, and the move key's slots stay correct across hotplug because they're computed from `kscreen-doctor` each press.