### PR TITLE
Bottom dock on every device, a lock key that locks, and a calmer unlocked look

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
+## v1.0.6 — Same place on every device
+
+### Changed
+
+- **Docked to the bottom, identically everywhere.** The default position is no longer a
+  pixel rect that happened to suit a 1280×800 Deck. `position_mode: "bottom"` (the new
+  default) ignores `geometry` and computes the spot from the panel: full width, flush with
+  the bottom edge, height a fraction of the display (`dock_height_frac`, 0.42; big mode
+  `big_height_frac`, 0.55). A Deck LCD, a Deck OLED and a Legion Go 2 now get the same
+  keyboard in the same place, which is how Steam's own OSK behaves.
+- **The lock key locks, it no longer moves anything.** Locking used to re-apply the
+  configured geometry, so the keyboard jumped back instead of staying where you dragged
+  it. It now reads back where you left it, forces exactly that rect, and stores it as
+  `position_mode: "custom"`. If the position can't be read back it still locks and leaves
+  the window alone rather than yanking it somewhere you didn't choose.
+- **Reset is its own key** (`kind: "reset"`, ⤓). Puts the keyboard back to the bottom dock
+  and forgets the custom spot.
+- **Unlocked mode looks calmer.** The drag bar was bright orange (it was reusing the
+  active-modifier colour). It's now a dark slate bar with a thin accent line, muted grip
+  labels, and the lock key uses its own accent style instead of the modifier one. Themable
+  via `handle_bg` / `handle_fg`.
+
+### Fixed
+
+- A second instance exiting on the single-instance lock no longer writes a crash log —
+  that's ordinary behaviour when the watchdog and autostart race, not a failure.
+- `geometry` and `big_geometry` are gone from the shipped config; they're derived. The
+  installer now uses `handheld-kbd-dock-rect` to seed the KWin rule so the first show
+  doesn't flash at the wrong size.
+
 ## v1.0.5 — Upgrades that actually upgrade
 
 Two bugs with the same shape: files that were only ever written on a *fresh* install, so

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ So I built the keyboard I wanted instead. Here's what it does differently:
   Toggles live, no relogin.
 - **Cycle transparency from the keyboard.** The ◐ key steps through
   `opacity_steps` instead of making you edit JSON to see what's underneath.
-- **Put it where you want it.** The ✥ key unlocks the keyboard: a bar appears
-  along the top, drag it anywhere, grab either end to resize, then press ✥ again
-  to lock it there. It remembers the spot. Useful when the bottom edge is where
-  the thing you're typing into lives, or when an external monitor has left the
-  keyboard on the wrong screen.
+- **Same place on every device.** It docks flush with the bottom edge, full
+  width, at a fixed fraction of the panel height — a Deck LCD, a Deck OLED and a
+  Legion Go 2 all get the same keyboard in the same spot.
+- **Or put it where you want it.** The ✥ key unlocks it: a bar appears along the
+  top, drag it anywhere, grab either end to resize, then press ✥ again to lock it
+  exactly there. ⤓ puts it back to the bottom dock.
 - **Swipe typing.** Drag across the letters instead of tapping them. Taps are
   unaffected — a drag only counts once it's unmistakably not one.
 - **Optional summon gestures.** Two-finger swipe up from the bottom edge

--- a/bin/handheld-kbd-dock-rect
+++ b/bin/handheld-kbd-dock-rect
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Print the default bottom-dock rect for the internal panel, as `X,Y W,H`.
+
+The keyboard works this out for itself at runtime; the installer uses this so the forced
+KWin rule starts out matching, instead of flashing the window at the wrong size on the
+first show. Prints nothing if the display can't be inspected — callers fall back.
+"""
+import json
+import os
+import subprocess
+import sys
+
+CFG = os.path.expanduser("~/.config/handheld-kbd/config.json")
+
+
+def frac():
+    try:
+        with open(CFG) as f:
+            return float(json.load(f).get("dock_height_frac", 0.42))
+    except Exception:
+        return 0.42
+
+
+def internal_panel():
+    try:
+        data = json.loads(subprocess.check_output(
+            ["kscreen-doctor", "-j"], text=True, timeout=5))
+    except Exception:
+        return None
+    outs = [o for o in data.get("outputs", []) if o.get("enabled")]
+    if not outs:
+        return None
+    chosen = next((o for o in outs if (o.get("name") or "").lower().startswith("edp")), outs[0])
+    mode = next((m for m in (chosen.get("modes") or [])
+                 if m.get("id") == chosen.get("currentModeId")), {})
+    size = mode.get("size") or chosen.get("size") or {}
+    if not size.get("width") or not size.get("height"):
+        return None
+    return int(size["width"]), int(size["height"])
+
+
+def main():
+    panel = internal_panel()
+    if not panel:
+        return 1
+    w, h = panel
+    kh = max(120, min(int(round(h * frac())), h))
+    print(f"0,{h - kh} {w},{kh}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -48,9 +48,17 @@ DEFAULT_CONFIG = {
     # The window position is offset by this output's origin. "" = auto-detect eDP* (the
     # internal panel). Only matters with 2+ displays; single-display is unaffected.
     "internal_output": "",
+    # Where the keyboard sits. "bottom" (the default) ignores `geometry` and docks flush
+    # with the bottom of the internal panel, full width, at a FRACTION of the panel height
+    # — so every device and resolution gets the same keyboard in the same place, like
+    # Steam's own OSK. "custom" uses `geometry`, which is what the lock key writes after
+    # you drag the keyboard somewhere. The reset key (kind "reset") goes back to "bottom".
+    "position_mode": "bottom",
+    "dock_height_frac": 0.42,
+    "big_height_frac": 0.55,
     # The move key (kind "move") unlocks the keyboard: KWin stops forcing its position and
-    # size, a drag bar appears, and you put it where you want — any edge, any display, any
-    # size. Pressing it again locks it there and saves the result back to `geometry`.
+    # size, a drag bar appears, and you put it where you want. Pressing it again locks it
+    # exactly there — it does not move the window — and saves the spot as `geometry`.
     "handle_height": 30,
     # "mirror": true  → the device's keyboard button summons us (via Steam's OSK).
     # "mirror": false → seamless mode: the daemon remaps the hardware keyboard button
@@ -179,9 +187,9 @@ def resolve_rows(layout):
         row = []
         for k in jrow:
             kind = k.get("kind", "")
-            if kind in ("locale", "hide", "size", "opacity", "move"):   # action keys: no keycode
+            if kind in ("locale", "hide", "size", "opacity", "move", "reset"):
                 dflt = {"locale": "🌐", "hide": "⌵", "size": "⤢",
-                        "opacity": "◐", "move": "✥"}.get(kind, "")
+                        "opacity": "◐", "move": "✥", "reset": "⤓"}.get(kind, "")
                 row.append((k.get("label", dflt), None, kind, "", ""))
                 continue
             name = k.get("key", "")
@@ -213,10 +221,14 @@ button.suggest:active {{ background: {t['key_active']}; }}
 button.suggest-empty {{ background: transparent; border-color: transparent; }}
 window.gm {{ background-color: rgba(0,0,0,0); }}
 .gm-keys {{ background-color: rgba(12,12,12,0.82); }}
-.handle-drag {{ background: {t['mod_on_bg']}; }}
-.handle-drag label {{ color: {t['mod_on_fg']}; font-weight: bold; }}
-.handle-grip {{ background: {t['key_active']}; padding: 0 14px; }}
-.handle-grip label {{ color: #ffffff; font-weight: bold; font-size: 18px; }}
+.handle-drag {{ background: {t.get('handle_bg', '#1e2733')};
+               border-top: 2px solid {t['key_active']}; }}
+.handle-drag label {{ color: {t.get('handle_fg', '#9fb4c7')}; font-size: 13px;
+                     letter-spacing: 1px; }}
+.handle-grip {{ background: {t.get('handle_bg', '#1e2733')};
+               border-top: 2px solid {t['key_active']}; padding: 0 16px; }}
+.handle-grip label {{ color: {t['key_active']}; font-size: 17px; }}
+button.unlocked {{ background: {t['key_active']}; color: #06121c; font-weight: bold; }}
 """.encode()
 
 
@@ -252,7 +264,7 @@ class OSK(Gtk.Window):
         # Uniform aligned grid: every key snaps to a column grid (column_homogeneous),
         # widths come from per-kind unit spans, rows centred → tidy, even alignment.
         kh = config["key_size"][1]
-        SPAN = {'': 2, 'wide': 3, 'mod': 3, 'space': 8, 'locale': 2, 'hide': 2, 'size': 2, 'opacity': 2}
+        SPAN = {'': 2, 'wide': 3, 'mod': 3, 'space': 8, 'locale': 2, 'hide': 2, 'reset': 2, 'size': 2, 'opacity': 2}
         row_units = [sum(SPAN.get(k[2], 2) for k in row) for row in rows]
         maxu = max(row_units) if row_units else 1
         grid = Gtk.Grid()
@@ -285,6 +297,9 @@ class OSK(Gtk.Window):
                     b.get_style_context().add_class('special')
                     b.connect("clicked", self.on_move)
                     self.move_btn = b
+                elif kind == 'reset':
+                    b.get_style_context().add_class('special')
+                    b.connect("clicked", self.on_reset)
                 elif kind == 'hide':
                     b.get_style_context().add_class('hide')
                     b.connect("clicked", lambda *_: self.dismiss())
@@ -790,7 +805,7 @@ class OSK(Gtk.Window):
         # so there big_key_h is what actually grows the docked strip.
         kh = self.cfg.get("big_key_h", 100) if (big and GAMEMODE) else self.norm_kh
         g = (self.cfg.get("big_geometry", DEFAULT_CONFIG["big_geometry"])
-             if big else self.cfg["geometry"])
+             if big else self.cfg.get("geometry", DEFAULT_CONFIG["geometry"]))
         if not GAMEMODE:
             # The suggestion row eats into a window whose size is FORCED by the KWin
             # rule. Left alone, full-height keys push the window's minimum past that
@@ -816,7 +831,7 @@ class OSK(Gtk.Window):
         # the bottom) — the taller key rows above already grow the strip, no resize/rule.
         if GAMEMODE:
             return
-        rect = self._slot_rect(g)
+        rect = self._slot_rect(g, big)
         self.resize(rect["w"], rect["h"])
         self.move(rect["x"], rect["y"])
         if not self.unlocked:                # unlocked: the user is placing it by hand
@@ -918,7 +933,9 @@ class OSK(Gtk.Window):
         if self.unlocked:
             self._set_rule_mode(4)              # Remember: KWin lets it be moved/resized
         else:
-            g = self._read_rule_geometry()      # whatever the user dragged it to
+            # Lock means "pin it exactly here" — never move the window. Read back where
+            # the user left it, force that rect, and remember it as the custom position.
+            g = self._read_rule_geometry()
             if g:
                 outs = self._outputs()
                 anchor = next((o for o in outs if o["internal"]), outs[0] if outs else None)
@@ -926,10 +943,30 @@ class OSK(Gtk.Window):
                 ox, oy = self._panel_origin()   # geometry is stored panel-relative
                 self.cfg["geometry"] = {"x": g["x"] - ox, "y": g["y"] - oy,
                                         "w": g["w"], "h": g["h"]}
+                self.cfg["position_mode"] = "custom"
                 self._persist("geometry", self.cfg["geometry"])
+                self._persist("position_mode", "custom")
                 self._last_rect = None          # so the re-force definitely writes
-            self._set_rule_mode(2)              # Force it to stay where they put it
-            self.apply_size()
+                self._set_rule_mode(2)          # Force — pins it where it already is
+                self._apply_kwin_geometry(g)
+            else:
+                # Couldn't read it back: still lock, but leave the window alone rather
+                # than yanking it somewhere the user didn't choose.
+                print("handheld-kbd: could not read back the dragged position; "
+                      "locking in place", file=sys.stderr)
+                self._set_rule_mode(2)
+        self._apply_handle()
+
+    def on_reset(self, btn):
+        """Put the keyboard back to the default bottom dock, forgetting a custom spot."""
+        if self._stray_tap():
+            return
+        self.unlocked = False
+        self.cfg["position_mode"] = "bottom"
+        self._persist("position_mode", "bottom")
+        self._last_rect = None
+        self._set_rule_mode(2)
+        self.apply_size()
         self._apply_handle()
 
     def _apply_handle(self):
@@ -942,9 +979,9 @@ class OSK(Gtk.Window):
                 self.handle.hide()
                 self.handle.set_no_show_all(True)
         if self.move_btn:
-            self._set_label(self.move_btn, "🔒" if self.unlocked else "✥", "")
+            self._set_label(self.move_btn, "🔓" if self.unlocked else "✥", "")
             ctx = self.move_btn.get_style_context()
-            (ctx.add_class if self.unlocked else ctx.remove_class)("mod-on")
+            (ctx.add_class if self.unlocked else ctx.remove_class)("unlocked")
 
     def _build_handle(self):
         """A thin bar: drag anywhere along it to move, use either end to resize.
@@ -1002,11 +1039,26 @@ class OSK(Gtk.Window):
         y = min(max(rect["y"], out["y"]), out["y"] + out["h"] - h)
         return {"x": x, "y": y, "w": w, "h": h}
 
-    def _slot_rect(self, g):
-        """Window rect for the configured geometry, anchored to the internal panel and
-        clamped to it, so it lands on-screen whatever the resolution."""
+    def _dock_rect(self, out, big):
+        """The default spot: full width, flush with the bottom edge, height a fixed
+        fraction of the panel. Steam's own on-screen keyboard sits like this, and because
+        it's a fraction rather than a pixel count it lands identically on a 1280x800 Deck,
+        an 800p OLED and a 1920x1200 Legion Go."""
+        frac = float(self.cfg.get("big_height_frac" if big else "dock_height_frac",
+                                  DEFAULT_CONFIG["big_height_frac" if big else "dock_height_frac"]))
+        h = max(120, min(int(round(out["h"] * frac)), out["h"]))
+        return {"x": out["x"], "y": out["y"] + out["h"] - h, "w": out["w"], "h": h}
+
+    def _slot_rect(self, g, big=False):
+        """Where the window goes: the bottom dock by default, or the position the user
+        dragged it to and locked (`position_mode: custom`). Always clamped to the panel."""
         outs = self._outputs()
         anchor = next((o for o in outs if o["internal"]), outs[0] if outs else None)
+        if self.cfg.get("position_mode", "bottom") != "custom" or not g:
+            if anchor:
+                return self._dock_rect(anchor, big)
+            # no display info: fall back to the configured rect as-is
+            g = g or dict(DEFAULT_CONFIG["geometry"])
         ox, oy = self._panel_origin()
         return self._clamp_rect(
             {"x": g["x"] + ox, "y": g["y"] + oy, "w": g["w"], "h": g["h"]}, anchor)
@@ -1472,6 +1524,8 @@ if __name__ == "__main__":
         pass
     try:
         main()
+    except SystemExit:
+        raise                       # e.g. the single-instance lock bowing out; not a crash
     except BaseException:
         try:
             with open("/tmp/handheld-kbd-crash.log", "w") as _f:

--- a/config/config.json
+++ b/config/config.json
@@ -10,18 +10,9 @@
     0.4,
     0.25
   ],
-  "geometry": {
-    "x": 0,
-    "y": 378,
-    "w": 1280,
-    "h": 422
-  },
-  "big_geometry": {
-    "x": 0,
-    "y": 256,
-    "w": 1280,
-    "h": 488
-  },
+  "position_mode": "bottom",
+  "dock_height_frac": 0.42,
+  "big_height_frac": 0.55,
   "big_key_h": 100,
   "start_big": false,
   "handle_height": 30,
@@ -56,7 +47,9 @@
     "mod_on_border": "#ffe000",
     "special_bg": "#2a2a2a",
     "special_fg": "#bbccdd",
-    "shifted_fg": "#7fb0ff"
+    "shifted_fg": "#7fb0ff",
+    "handle_bg": "#1e2733",
+    "handle_fg": "#9fb4c7"
   },
   "hotkey": [],
   "mirror": true,

--- a/config/layouts/compact.json
+++ b/config/layouts/compact.json
@@ -85,6 +85,10 @@
         "kind": "move"
       },
       {
+        "label": "⤓",
+        "kind": "reset"
+      },
+      {
         "label": "⌵",
         "kind": "hide"
       }

--- a/config/layouts/full.json
+++ b/config/layouts/full.json
@@ -67,6 +67,10 @@
         "kind": "move"
       },
       {
+        "label": "⤓",
+        "kind": "reset"
+      },
+      {
         "label": "⌵",
         "kind": "hide"
       }

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ install -m755 "$HERE/bin/handheld-kbd-swap.sh"   "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-relogin"   "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-ip-remap"  "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-recover"   "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-dock-rect" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-build-dict" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-focus-probe" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-resume.sh"  "$BIN/"
@@ -180,46 +181,10 @@ PY
   fi
 fi
 
-# --- size the keyboard for THIS panel (fresh installs only) ---
-# The shipped geometry suits a 1280x800 Steam Deck. On any other panel it would be the
-# wrong width and, on a shorter screen, hang off the bottom. Derive it from the internal
-# display instead: full width, 55% height (capped), docked to the bottom edge. The
-# keyboard clamps at runtime too, so this only makes the first launch look right.
-PANEL_W=""; PANEL_H=""
-if [ "$FRESH" = 1 ] && command -v kscreen-doctor >/dev/null 2>&1; then
-  eval "$(python3 - <<'PY' 2>/dev/null
-import json, subprocess
-try:
-    data = json.loads(subprocess.check_output(["kscreen-doctor", "-j"], text=True, timeout=5))
-except Exception:
-    raise SystemExit(0)
-outs = [o for o in data.get("outputs", []) if o.get("enabled")]
-if not outs:
-    raise SystemExit(0)
-def size(o):
-    mode = next((m for m in (o.get("modes") or []) if m.get("id") == o.get("currentModeId")), {})
-    s = mode.get("size") or o.get("size") or {}
-    return s.get("width"), s.get("height")
-internal = next((o for o in outs if (o.get("name") or "").lower().startswith("edp")), outs[0])
-w, h = size(internal)
-if w and h:
-    print(f'PANEL_W={int(w)}; PANEL_H={int(h)}')
-PY
-)"
-fi
-if [ -n "$PANEL_W" ] && [ -n "$PANEL_H" ]; then
-  say "Sizing for this panel: ${PANEL_W}x${PANEL_H}"
-  python3 - "$CFG/config.json" "$PANEL_W" "$PANEL_H" <<'PY'
-import json, sys
-p, W, H = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-d = json.load(open(p))
-h = min(int(H * 0.55), max(240, int(H * 0.55)))          # 55% of the panel
-big = min(int(H * 0.64), H)
-d["geometry"] = {"x": 0, "y": H - h, "w": W, "h": h}
-d["big_geometry"] = {"x": 0, "y": H - big, "w": W, "h": big}
-json.dump(d, open(p, "w"), indent=2)
-PY
-fi
+# --- work out the bottom dock for THIS panel (for the initial KWin rule) ---
+# The keyboard computes this itself at runtime from dock_height_frac; this only stops the
+# forced rule flashing the window at the wrong size on the very first show.
+PANEL_RECT="$(python3 "$HERE/bin/handheld-kbd-dock-rect" 2>/dev/null || true)"
 
 # --- KWin translucency script ---
 # Generated, never copied: a static copy used to be installed here and it diverged from
@@ -250,14 +215,7 @@ if command -v kwriteconfig6 >/dev/null 2>&1; then
   # on first show. The keyboard rewrites both live (move key, big mode), so this is just
   # the starting point — but on a panel that isn't 1280x800 the old hardcoded values put
   # the window partly off-screen until something moved it.
-  RULE_GEOM="$(python3 -c '
-import json, sys
-try:
-    g = json.load(open(sys.argv[1]))["geometry"]
-    print("%d,%d %d,%d" % (g["x"], g["y"], g["w"], g["h"]))
-except Exception:
-    print("0,378 1280,422")
-' "$CFG/config.json" 2>/dev/null || echo "0,378 1280,422")"
+  RULE_GEOM="${PANEL_RECT:-0,378 1280,422}"
   RULE_POS="${RULE_GEOM%% *}"; RULE_SIZE="${RULE_GEOM##* }"
   "${K[@]}" position "$RULE_POS";  "${K[@]}" positionrule 2
   "${K[@]}" size "$RULE_SIZE";     "${K[@]}" sizerule 2


### PR DESCRIPTION
Four things from testing on the Legion Go 2.

## 1. Same position on every device and resolution

The default position was a pixel rect (`0,378 1280x422`) that suited a 1280×800 Deck and nothing else — on the Go 2's 1920×1200 panel it sat mid-screen, floating.

`position_mode: "bottom"` is the new default. It ignores `geometry` and derives the rect from the panel: full width, flush with the bottom edge, height = `dock_height_frac` (0.42; big mode uses `big_height_frac`, 0.55). Fractions, not pixels, so it's the same keyboard in the same place everywhere:

| panel | normal | big |
|---|---|---|
| Deck LCD / OLED 1280×800 | `0,464 1280x336` | `0,360 1280x440` |
| Legion Go 2 1920×1200 | `0,696 1920x504` | `0,540 1920x660` |
| 1280×720 | `0,418 1280x302` | `0,324 1280x396` |
| 3840×2160 | `0,1253 3840x907` | `0,972 3840x1188` |

All bottom-flush by construction. Verified live on the Go 2 — the rule reads `0,696 1920,504` after the change.

## 2. The lock key locks instead of resetting

Locking called `apply_size()`, which recomputed from the configured geometry — so the keyboard jumped back rather than staying where it was dragged. It now reads back the dragged rect, forces exactly that, and stores `position_mode: "custom"`. If the read-back fails it still locks but leaves the window untouched, rather than moving it somewhere the user didn't pick.

## 3. Reset is its own key

`kind: "reset"` (⤓), added to both layouts next to ✥. Restores the bottom dock and forgets the custom spot.

## 4. The orange was ugly

The drag bar was reusing `mod_on_bg` — the bright orange used for a held modifier. Unlocked mode is now a dark slate bar (`handle_bg` `#1e2733`) with a thin accent line in the theme's active colour, muted grip glyphs, and the lock key gets its own `.unlocked` accent style rather than the modifier one. Both colours are themable.

## Also

- A duplicate instance exiting via the single-instance lock no longer writes a crash log — that's the watchdog racing autostart, not a failure.
- `geometry` / `big_geometry` dropped from the shipped config (they're derived); `bin/handheld-kbd-dock-rect` seeds the initial KWin rule so the first show doesn't flash at the wrong size.

Deployed to the Go 2 and running. Ready to tag for the Deck OLED test.