### PR TITLE
Recover the hardware button when InputPlumber drops the controller

### DIFF
--- a/bin/handheld-kbd-kwin-script
+++ b/bin/handheld-kbd-kwin-script
@@ -77,6 +77,12 @@ PLACE="${1:-dock}"; FRAC="${2:-0.42}"; CX="${3:-0}"; CY="${4:-0}"; CW="${5:-0}";
 # says "bottom", or the keyboard is dragged straight back the moment the user lets go.
 # --dock 0 means the user is dragging: no placement at all until they finish.
 case "$DOCK_OVERRIDE" in 0) PLACE="none" ;; 1) PLACE="dock" ;; esac
+# A runtime fallback beats the config: the daemon sets this when the hardware-button remap
+# could not be applied, and without honouring it here every regeneration of this script
+# would turn mirroring back off while the button is still dead.
+if [ -z "$MIRROR" ] && [ -f /tmp/handheld-kbd.mirror-fallback ]; then
+    MIRROR=1
+fi
 if [ -z "$MIRROR" ]; then
     MIRROR=$(python3 -c 'import json,os
 try: print(0 if json.load(open(os.path.expanduser("~/.config/handheld-kbd/config.json"))).get("mirror", True) is False else 1)

--- a/bin/handheld-kbd-swap.sh
+++ b/bin/handheld-kbd-swap.sh
@@ -58,9 +58,26 @@ write_opscript "$HIDE_STEAM"
 # Seamless mode: remap the hardware keyboard button (via InputPlumber) so it fires our
 # DBus event instead of triggering Steam's OSK. If that remap can't be applied, fall back
 # to mirror mode for this session — better a keyboard on Steam's trigger than no keyboard.
-if [ "$MIRROR" = 0 ] && [ -x "$HOME/.local/bin/handheld-kbd-ip-remap" ]; then
-    if ! "$HOME/.local/bin/handheld-kbd-ip-remap" >>/tmp/swap-startup.log 2>&1; then
-        echo "REMAP FAILED $(date) — falling back to mirror mode" >>/tmp/swap-startup.log
+# The fallback is recorded in a file, not just a variable: the keyboard regenerates the
+# KWin script too (opacity key, placement changes) and would otherwise write MIRROR=0 back,
+# silently undoing the fallback while the trigger is still dead.
+FALLBACK=/tmp/handheld-kbd.mirror-fallback
+rm -f "$FALLBACK"
+SEAMLESS_WANTED=0
+[ "$MIRROR" = 0 ] && SEAMLESS_WANTED=1
+
+apply_remap() {          # 0 = the hardware button now drives us
+    [ -x "$HOME/.local/bin/handheld-kbd-ip-remap" ] || return 1
+    "$HOME/.local/bin/handheld-kbd-ip-remap" >>/tmp/swap-startup.log 2>&1
+}
+
+REMAPPED=0
+if [ "$SEAMLESS_WANTED" = 1 ]; then
+    if apply_remap; then
+        REMAPPED=1
+    else
+        echo "REMAP FAILED $(date) — mirroring Steam's OSK until it can be applied" >>/tmp/swap-startup.log
+        : > "$FALLBACK"
         MIRROR=1
         HIDE_STEAM=$(hide_steam_wanted)
         write_opscript "$HIDE_STEAM"
@@ -87,6 +104,36 @@ while true; do
             HIDE_STEAM=$want
             write_opscript "$HIDE_STEAM"
             load_opscript
+        fi
+    fi
+
+    # InputPlumber drops its composite device whenever the controller re-enumerates — on a
+    # Legion Go that happens when the pads are detached, or the service restarts. The remap
+    # goes with it and the hardware button quietly stops working. Keep trying until it
+    # sticks, then drop the mirror fallback.
+    if [ "$SEAMLESS_WANTED" = 1 ] && [ "$REMAPPED" = 0 ]; then
+        retry=$((${retry:-0} + 1))
+        if [ "$retry" -ge 5 ]; then          # every ~10s
+            retry=0
+            if apply_remap; then
+                REMAPPED=1
+                rm -f "$FALLBACK"
+                MIRROR=0
+                echo "REMAP RECOVERED $(date) — hardware button live again" >>/tmp/swap-startup.log
+                HIDE_STEAM=$(hide_steam_wanted)
+                write_opscript "$HIDE_STEAM"
+                load_opscript
+            fi
+        fi
+    elif [ "$SEAMLESS_WANTED" = 1 ] && [ "$REMAPPED" = 1 ]; then
+        # ...and notice if it goes away again.
+        check=$((${check:-0} + 1))
+        if [ "$check" -ge 15 ]; then         # every ~30s
+            check=0
+            if ! busctl --system tree org.shadowblip.InputPlumber 2>/dev/null | grep -q CompositeDevice; then
+                REMAPPED=0
+                echo "REMAP LOST $(date) — InputPlumber has no composite device" >>/tmp/swap-startup.log
+            fi
         fi
     fi
 


### PR DESCRIPTION
The hardware keyboard button stopped working on my Legion Go 2 today. Not a regression — the evidence from the device:

```
19:58:58  inputplumber: Found missing hidraw device ... CompositeDevice stopped: .../CompositeDevice0
19:58:58  inputplumber: Gamepad order: []
19:59:16  handheld-kbd: profile did not load on any InputPlumber device — seamless trigger inactive
19:59:16  REMAP FAILED — falling back to mirror mode
```

InputPlumber tears down its composite device when the controller re-enumerates (detaching the pads on a Legion Go does it, so does restarting the service). The button remap dies with it. We applied that remap exactly once, at daemon startup, so the button stayed dead until someone noticed and restarted things by hand. `systemctl restart inputplumber` + re-running the remap brought it straight back.

## Changes

**Retry until it sticks.** While seamless mode is wanted but the remap isn't applied, the supervisor retries every ~10s. Once applied, it re-checks every ~30s that a composite device still exists, so a later detach is noticed and recovery starts again. Both transitions are logged (`REMAP RECOVERED`, `REMAP LOST`).

**The mirror fallback now survives.** It was only a shell variable in the daemon, but the *keyboard* regenerates the KWin script as well — on opacity changes and placement changes — and that regeneration read `mirror` from config and wrote `MIRROR=0` back. So the daemon's fallback was silently undone while the hardware trigger was still dead, which leaves no way to summon the keyboard at all. It's now a flag file (`/tmp/handheld-kbd.mirror-fallback`) that the script writer honours regardless of which process regenerates it.

Deployed and running on the Go 2. The Deck is on v1.0.8 and will pick this up with the next release.