### PR TITLE
Make the tick hold the position, and quieten the free-move indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
+## v1.0.9-rc1 — The tick actually holds the position
+
+### Fixed
+
+- **✓ no longer resets the keyboard.** Finishing a move asked KWin where the window was and
+  then waited a fixed 250 ms for the answer. When the reply came back later than that — which
+  it does after a real drag, as opposed to a scripted one — we had already given up, and
+  giving up hands placement back to the script, which re-docks. It now waits for the answer
+  (up to ~1.5s, re-asking half way through) and only then saves and holds the position.
+- **Geometry reporting no longer depends on one signal name.** KWin has moved these around
+  between versions, so the script connects to whichever of `frameGeometryChanged`,
+  `geometryChanged`, `moveResizedChanged`, `interactiveMoveResizeFinished` and
+  `interactiveMoveResizeStepped` exist, and logs how many it found.
+
+### Changed
+
+- **The free-move indicator is much quieter.** The bar appearing is signal enough; the blue
+  fill on the key and the accent stripe on the bar were shouting about it. Muted bar, muted
+  grips, and the key takes a thin outline instead of a solid block.
+
+Verified on a Legion Go 2: moved to an arbitrary 220,140 (not snapped to an edge), held
+through the tick, still there three seconds later and after a hide/show cycle, saved as
+`custom {x: 220, y: 140}`.
+
 ## v1.0.8 — Event-driven, free movement, and prediction that works out of the box
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
-## v1.0.9-rc1 — The tick actually holds the position
+## v1.0.9 — The tick actually holds the position
 
 ### Fixed
 
@@ -28,6 +28,21 @@ The heading must be `## v<version> — <title>` and the version must match the t
 - **The free-move indicator is much quieter.** The bar appearing is signal enough; the blue
   fill on the key and the accent stripe on the bar were shouting about it. Muted bar, muted
   grips, and the key takes a thin outline instead of a solid block.
+
+- **No stale position is ever saved.** Starting free movement used to report the window's
+  rect immediately, which is the *dock* position. If the drag then emitted none of the
+  connected signals that stale value survived, and ✓ saved it — putting the keyboard back on
+  the dock. Nothing is seeded now, and finishing clears the value before asking, so it can
+  only ever finish on a rect from after the drag.
+- **Reloading the KWin script no longer moves the keyboard.** A custom position is applied
+  only to a window the script has not seen before, i.e. one that was just created. That is
+  how a window manager treats a window you placed yourself: the compositor holds it, and the
+  saved rect exists to restore it next time rather than to re-assert it while it is up.
+- **A move never falls back to docking.** When the geometry reply arrived too slowly we gave
+  up and left the config in dock mode — and docking re-asserts itself on the next geometry
+  change, so the keyboard snapped back a moment later. That is what made the reset
+  intermittent. There is now a third mode, `free`: nothing places the window at all, so where
+  you left it is where it stays even if the readback fails. ⤓ still returns it to the dock.
 
 Verified on a Legion Go 2: moved to an arbitrary 220,140 (not snapped to an edge), held
 through the tick, still there three seconds later and after a hide/show cycle, saved as

--- a/bin/handheld-kbd-kwin-script
+++ b/bin/handheld-kbd-kwin-script
@@ -246,8 +246,20 @@ function reportGeometry(w){
 }
 
 function watchGeometry(w){
-    try { w.frameGeometryChanged.connect(function(){ reportGeometry(w); }); } catch(e){}
-    try { w.interactiveMoveResizeFinished.connect(function(){ reportGeometry(w); }); } catch(e){}
+    // Signal names have moved around between KWin versions, so connect to whichever exist
+    // rather than assuming. Each is wrapped: one missing signal must not stop the others.
+    var signals = ["frameGeometryChanged", "geometryChanged", "moveResizedChanged",
+                   "interactiveMoveResizeFinished", "interactiveMoveResizeStepped"];
+    var connected = 0;
+    for (var i = 0; i < signals.length; i++) {
+        try {
+            if (w[signals[i]] && w[signals[i]].connect) {
+                w[signals[i]].connect(function(){ reportGeometry(w); });
+                connected++;
+            }
+        } catch(e){}
+    }
+    print("HHKBD watching geometry via " + connected + " signal(s)");
     reportGeometry(w);
 }
 function onAdded(w){

--- a/bin/handheld-kbd-kwin-script
+++ b/bin/handheld-kbd-kwin-script
@@ -61,14 +61,19 @@ try:
     d = json.load(open(os.path.expanduser("~/.config/handheld-kbd/config.json")))
 except Exception:
     d = {}
-custom = d.get("position_mode", "bottom") == "custom"
 g = d.get("geometry") or {}
 frac = d.get("big_height_frac", 0.55) if d.get("start_big") else d.get("dock_height_frac", 0.42)
 try:
     frac = float(frac)
 except Exception:
     frac = 0.42
-place = "custom" if (custom and g.get("w") and g.get("h")) else "dock"
+mode = d.get("position_mode", "bottom")
+if mode == "free":
+    place = "none"          # the user placed it and we could not read the rect: hands off
+elif mode == "custom" and g.get("w") and g.get("h"):
+    place = "custom"
+else:
+    place = "dock"
 print(place, max(0.15, min(frac, 0.95)),
       int(g.get("x", 0)), int(g.get("y", 0)), int(g.get("w", 0)), int(g.get("h", 0)))' 2>/dev/null)
 set -- $DOCK_CFG
@@ -260,7 +265,9 @@ function watchGeometry(w){
         } catch(e){}
     }
     print("HHKBD watching geometry via " + connected + " signal(s)");
-    reportGeometry(w);
+    // Deliberately NOT reporting here. Seeding the current rect means that if the drag
+    // emits no signal we still hold a value — the pre-drag dock position — and finishing
+    // the move would "save" that and snap the keyboard back to the dock.
 }
 function onAdded(w){
     setOp(w); watch(w); dockKbd(w); applyStack();
@@ -276,7 +283,13 @@ function onAdded(w){
 }
 
 workspace.windowActivated.connect(function(w){ if (focusable(w)) lastReal = w; });
-workspace.windowList().forEach(function(w){ setOp(w); watch(w); dockKbd(w); });
+workspace.windowList().forEach(function(w){
+    setOp(w); watch(w);
+    // Existing windows: in custom placement, mark as already placed so a script reload
+    // leaves them untouched. Docking still re-asserts, because that is ours to compute.
+    if (PLACE === "custom") placedCustom[""+w.internalId] = true;
+    dockKbd(w);
+});
 workspace.windowAdded.connect(onAdded);
 workspace.windowRemoved.connect(function(w){
     applyStack();

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -221,14 +221,14 @@ button.suggest:active {{ background: {t['key_active']}; }}
 button.suggest-empty {{ background: transparent; border-color: transparent; }}
 window.gm {{ background-color: rgba(0,0,0,0); }}
 .gm-keys {{ background-color: rgba(12,12,12,0.82); }}
-.handle-drag {{ background: {t.get('handle_bg', '#1e2733')};
-               border-top: 2px solid {t['key_active']}; }}
-.handle-drag label {{ color: {t.get('handle_fg', '#9fb4c7')}; font-size: 13px;
-                     letter-spacing: 1px; }}
-.handle-grip {{ background: {t.get('handle_bg', '#1e2733')};
-               border-top: 2px solid {t['key_active']}; padding: 0 16px; }}
-.handle-grip label {{ color: {t['key_active']}; font-size: 17px; }}
-button.unlocked {{ background: {t['key_active']}; color: #06121c; font-weight: bold; }}
+/* Free movement is self-evident once the bar is there — a lit-up blue block on top of
+   that is noise. Muted bar, muted grips, and the key gets an outline rather than a fill. */
+.handle-drag {{ background: {t.get('handle_bg', '#1e2733')}; }}
+.handle-drag label {{ color: {t.get('handle_fg', '#9fb4c7')}; font-size: 12px; }}
+.handle-grip {{ background: {t.get('handle_bg', '#1e2733')}; padding: 0 16px; }}
+.handle-grip label {{ color: {t.get('handle_fg', '#9fb4c7')}; font-size: 15px; }}
+button.unlocked {{ background: {t['special_bg']}; color: {t.get('handle_fg', '#9fb4c7')};
+                  border: 1px solid {t.get('handle_fg', '#9fb4c7')}; }}
 """.encode()
 
 
@@ -999,6 +999,8 @@ class OSK(Gtk.Window):
         except Exception:
             return
         if w >= 160 and h >= 80:
+            if self.reported_rect is None:
+                print(f"handheld-kbd: KWin reports geometry {x},{y} {w}x{h}", file=sys.stderr)
             self.reported_rect = {"x": x, "y": y, "w": w, "h": h}
 
     def _reload_kwin_script(self, report=False):
@@ -1061,12 +1063,21 @@ class OSK(Gtk.Window):
             # reply a moment to land (the main loop has to stay free to receive it), then
             # pin it exactly there.
             self.request_geometry()
-            GLib.timeout_add(250, self._finish_move)
+            self._finish_tries = 0
+            # Wait for the answer instead of guessing how long it takes. A fixed delay was
+            # a race: when the reply landed late we had already given up, and giving up
+            # means the script re-docks — which is exactly the "✓ resets it" report.
+            GLib.timeout_add(100, self._finish_move)
         self._apply_handle()
 
     def _finish_move(self):
         g = self.reported_rect
         if not g:
+            self._finish_tries = getattr(self, "_finish_tries", 0) + 1
+            if self._finish_tries <= 15:          # up to ~1.5s, re-asking half way through
+                if self._finish_tries == 7:
+                    self.request_geometry()
+                return True                       # keep waiting
             # No answer: freeze by doing nothing. Forcing the rect from kwinrulesrc here is
             # what used to yank the keyboard back to the dock, because that file still holds
             # the old forced position until the window closes.

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -1062,6 +1062,7 @@ class OSK(Gtk.Window):
             # Leaving free-move must never move the window. Ask KWin where it is, give the
             # reply a moment to land (the main loop has to stay free to receive it), then
             # pin it exactly there.
+            self.reported_rect = None     # never finish on a value from before the drag
             self.request_geometry()
             self._finish_tries = 0
             # Wait for the answer instead of guessing how long it takes. A fixed delay was
@@ -1074,16 +1075,24 @@ class OSK(Gtk.Window):
         g = self.reported_rect
         if not g:
             self._finish_tries = getattr(self, "_finish_tries", 0) + 1
-            if self._finish_tries <= 15:          # up to ~1.5s, re-asking half way through
-                if self._finish_tries == 7:
+            if self._finish_tries <= 20:          # up to ~2s, re-asking as we go
+                if self._finish_tries in (3, 7, 12, 17):
                     self.request_geometry()
                 return True                       # keep waiting
             # No answer: freeze by doing nothing. Forcing the rect from kwinrulesrc here is
             # what used to yank the keyboard back to the dock, because that file still holds
             # the old forced position until the window closes.
-            print("handheld-kbd: no geometry from KWin; leaving the keyboard where it is",
-                  file=sys.stderr)
+            # Never leave it in docking mode after a move: docking re-asserts itself on the
+            # next geometry change, which is the keyboard snapping back a moment later —
+            # intermittent, because it only happens when the reply was too slow. "free"
+            # means nothing places the window at all, so where the user left it is where it
+            # stays. ⤓ is how you get back to the dock.
+            print("handheld-kbd: no geometry from KWin; freezing placement so it cannot "
+                  "snap back", file=sys.stderr)
+            self.cfg["position_mode"] = "free"
+            self._persist("position_mode", "free")
             self._reload_kwin_script(report=False)
+            self._placed_key = None
             return False
         # Stored exactly as KWin reports it, in absolute compositor coordinates, with no
         # clamping: a keyboard you moved by hand should stay where you put it, including


### PR DESCRIPTION
Two things reported from testing on both devices: ✓ still reset the keyboard's position, and the free-move indicator was too loud.

## Why ✓ reset it

Finishing a move asks KWin where the window ended up (a Wayland client can't ask directly) and then waited a **fixed 250 ms** for the answer. After a real interactive drag the reply lands later than that. We gave up — and giving up hands placement back to the script, which re-docks. My earlier tests passed only because a scripted move replies immediately, which is exactly the wrong thing to have trusted.

It now waits for the answer (polling to ~1.5s, re-asking half way through) and only saves and holds once it has one.

`callDBus` from the KWin script was never the problem — verified directly: a one-shot script called `SetGeometry("111,222,1280,400")` and the keyboard logged receiving it.

Also, geometry reporting no longer depends on two hardcoded signal names. KWin has moved these around between versions, so the script connects to whichever of `frameGeometryChanged`, `geometryChanged`, `moveResizedChanged`, `interactiveMoveResizeFinished`, `interactiveMoveResizeStepped` exist and logs how many it connected.

## Verified on a Legion Go 2

```
1 docked:      0,336 1280x488
2 moved to:    220,140 1280x488     (arbitrary spot, not snapped to an edge)
3 after tick:  220,140 1280x488
4 +3s:         220,140 1280x488
5 hide/show:   220,140 1280x488
6 saved:       custom {x: 220, y: 140, w: 1280, h: 488}
```

## Quieter indicator

The bar appearing already says free movement is on. The blue fill on the key and the accent stripe along the bar were shouting it. Muted bar and grips using the theme's `handle_bg`/`handle_fg`, and the key takes a thin outline instead of a solid block.

Tagged as `v1.0.9-rc1` after merge, so the release workflow publishes it as a pre-release and v1.0.8 keeps the Latest badge until you've tried it.