### PR TITLE
Stop Steam's on-screen keyboard from stealing the Deck's trackpads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
+## v1.0.10 — The Steam Deck keeps its trackpads
+
+### Fixed
+
+- **The trackpads and stick pointer keep working while the keyboard is up.** On a Steam
+  Deck the keyboard is summoned by Steam's own on-screen keyboard appearing, and we hid
+  that keyboard by setting its opacity to zero. The window stayed mapped, so Steam went on
+  believing its keyboard was open — and while it believes that, it forces the controller
+  into its "KB ActionSet", where the sticks and trackpads navigate *that* keyboard instead
+  of moving the desktop pointer. Steam says so in its own log:
+
+  ```
+  Set OSK active 1 and appid 413080
+  OnFocusWindowChanged On Screen Keyboard Forcing to window type: KB ActionSet, AppID 769
+  ```
+
+  So you got a keyboard you could only use by touch, and no pointer at all until Steam was
+  restarted. Steam's keyboard is now closed rather than hidden, which makes Steam set
+  OSK-active back to 0 and reload the desktop controller config. Fixes #14.
+
+  This never affected the Legion Go, where the hardware button is remapped through
+  InputPlumber and Steam's keyboard is never involved.
+
+- **The hardware keyboard button toggles again.** Closing Steam's keyboard means Steam no
+  longer reports a second press as a close — it just opens a fresh one — so the button is
+  handled as a toggle in the compositor rather than mirroring Steam's show and hide.
+
+- **A session that is already stuck recovers without restarting Steam.** Loading the KWin
+  script closes any Steam keyboard left over from before, and `handheld-kbd-fix-pointer`
+  does the same on demand. It no longer restarts Steam: a half-started Steam client leaves
+  you with no pointer at all, which is worse than what it was fixing.
+
+- **`handheld-kbd-ctl` starts the keyboard under the user service manager.** Started from
+  an SSH shell it used to inherit no display and no session bus, and came up unable to draw
+  or to answer on DBus — precisely when you are least able to debug it.
+
+### Added
+
+- **Application-menu shortcuts.** Show/hide, restart, stop, reset position, and fix the
+  trackpad pointer. Typing a command is the one thing you cannot do when the keyboard is
+  the problem, so every recovery action is also something you can click.
+- **`handheld-kbd-ctl`** — `status`, `start`, `stop`, `restart`, `reset` for the keyboard
+  and its supervisor, without logging out. Every action is safe to repeat.
+
 ## v1.0.9 — The tick actually holds the position
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ So I built the keyboard I wanted instead. Here's what it does differently:
   bottom dock.
 - **It doesn't need Steam.** `handheld-kbd-toggle` shows and hides it directly, so
   a dead Steam client can't leave you without a keyboard. Bind it to a shortcut.
+- **Your trackpads still work.** On a Deck, Steam's own keyboard is what summons this
+  one — and while Steam thinks its keyboard is open, the sticks and trackpads navigate
+  *that* instead of moving the pointer. Steam's keyboard is closed rather than hidden, so
+  the pointer stays yours.
+- **Shortcuts for when it goes wrong.** Show/hide, restart, stop, reset position and fix
+  the trackpad pointer all appear in the application menu — clickable, because typing is
+  the one thing you can't do when the keyboard is the problem.
 - **Swipe typing.** Drag across the letters instead of tapping them. Taps are
   unaffected — a drag only counts once it's unmistakably not one.
 - **Optional summon gestures.** Two-finger swipe up from the bottom edge
@@ -97,6 +104,31 @@ rather matters when you have no keyboard.
 
 Want out entirely? `handheld-kbd-recover --stock-only` stands everything down and hands the
 desktop back to Steam's keyboard.
+
+## Trackpads or stick pointer stopped working?
+
+Versions before 1.0.10 hid Steam's on-screen keyboard instead of closing it. Steam kept
+believing its keyboard was open, and while it believes that it puts the controller in its
+"KB ActionSet" — sticks and trackpads navigate Steam's keyboard rather than moving the
+pointer. Update, and if a session is still stuck:
+
+```bash
+handheld-kbd-fix-pointer
+```
+
+Or click **Fix Trackpad and Stick Pointer** in the application menu. It closes the leftover
+window; no Steam restart, no relogin.
+
+## Controlling it
+
+```bash
+handheld-kbd-ctl status      # what's running, and where the keyboard is
+handheld-kbd-ctl restart     # the usual fix
+handheld-kbd-ctl stop        # until you start it again or log back in
+handheld-kbd-ctl reset       # back to the bottom dock
+```
+
+All of these are in the application menu too.
 
 ## Predictive text
 

--- a/bin/handheld-kbd-ctl
+++ b/bin/handheld-kbd-ctl
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Start, stop and restart the keyboard without logging out.
+#
+# The keyboard normally looks after itself: the supervisor starts it at login and
+# respawns it if it dies. This is for the times it doesn't — a bad config edit, a
+# wedged Wayland connection, or a position you want to put back.
+#
+#   handheld-kbd-ctl status      what is running, and where the keyboard is
+#   handheld-kbd-ctl start       start the supervisor (and so the keyboard)
+#   handheld-kbd-ctl stop        stop both; nothing respawns until you start it again
+#   handheld-kbd-ctl restart     stop, then start — the usual fix
+#   handheld-kbd-ctl reset       put the keyboard back on the bottom dock
+#
+# Every action is safe to repeat: stopping something already stopped is a no-op,
+# and starting something already running restarts it rather than running two.
+set -u
+
+BIN="$HOME/.local/bin"
+KBD_PAT='python3 .*handheld-kbd\.py'
+SUP_PAT='handheld-kbd-swap\.sh'
+
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+# Match by pattern but never kill ourselves or our own parents: `handheld-kbd-ctl`
+# run from a shell whose argv mentions the pattern would otherwise take the shell
+# with it, which is a memorable way to lose an SSH session.
+kill_pattern() {
+    local pat="$1" sig="${2:-TERM}" p
+    for p in $(pgrep -f "$pat" 2>/dev/null); do
+        [ "$p" = "$$" ] && continue
+        [ "$p" = "$PPID" ] && continue
+        kill "-$sig" "$p" 2>/dev/null
+    done
+}
+
+running() { pgrep -f "$1" >/dev/null 2>&1; }
+
+stop_all() {
+    systemctl --user stop handheld-kbd >/dev/null 2>&1
+    kill_pattern "$SUP_PAT"           # supervisor first, or it respawns the keyboard
+    sleep 0.5
+    kill_pattern "$KBD_PAT"
+    for _ in $(seq 12); do
+        running "$KBD_PAT" || break
+        sleep 0.25
+    done
+    kill_pattern "$KBD_PAT" KILL
+    rm -f /tmp/handheld-kbd-swap.lock
+}
+
+start_all() {
+    # Start under the user service manager rather than from this shell. Run over SSH —
+    # which is exactly where you end up when the keyboard is the problem — this shell has
+    # no display and no session bus, and a keyboard inheriting that comes up unable to
+    # open a display or to answer on DBus. The service manager has the real session
+    # environment, imported at login.
+    if command -v systemd-run >/dev/null 2>&1; then
+        systemctl --user reset-failed handheld-kbd >/dev/null 2>&1
+        systemd-run --user --collect --unit=handheld-kbd \
+            "$BIN/handheld-kbd-swap.sh" >/dev/null 2>&1 \
+            || setsid "$BIN/handheld-kbd-swap.sh" >>/tmp/handheld-kbd-out.log 2>&1 &
+    else
+        setsid "$BIN/handheld-kbd-swap.sh" >>/tmp/handheld-kbd-out.log 2>&1 &
+    fi
+    for _ in $(seq 40); do            # the supervisor spawns the keyboard itself
+        running "$KBD_PAT" && break
+        sleep 0.25
+    done
+}
+
+case "${1:-restart}" in
+    status)
+        running "$SUP_PAT" && echo "supervisor: running" || echo "supervisor: stopped"
+        running "$KBD_PAT" && echo "keyboard:   running" || echo "keyboard:   stopped"
+        echo "visible:    $([ "$(cat /tmp/handheld-kbd.vis 2>/dev/null)" = 1 ] && echo yes || echo no)"
+        python3 - <<'PY' 2>/dev/null
+import json, os
+p = os.path.expanduser("~/.config/handheld-kbd/config.json")
+try:
+    c = json.load(open(p))
+except Exception:
+    raise SystemExit
+print("position:   %s %s" % (c.get("position_mode", "bottom"), c.get("geometry", "")))
+PY
+        ;;
+    stop)
+        stop_all
+        echo "keyboard stopped. 'handheld-kbd-ctl start' brings it back."
+        ;;
+    start)
+        stop_all                      # idempotent: never end up with two supervisors
+        start_all
+        running "$KBD_PAT" && echo "keyboard started." || { echo "keyboard did not start — see /tmp/handheld-kbd-out.log" >&2; exit 1; }
+        ;;
+    restart)
+        stop_all
+        start_all
+        running "$KBD_PAT" && echo "keyboard restarted." || { echo "keyboard did not come back — see /tmp/handheld-kbd-out.log" >&2; exit 1; }
+        ;;
+    reset)
+        # Ask the running keyboard first so the change is visible immediately; fall
+        # back to editing the config for a keyboard that isn't up to answer.
+        if busctl --user call org.handheld.Keyboard /org/handheld/Keyboard \
+                 org.handheld.Keyboard Reset >/dev/null 2>&1; then
+            echo "keyboard reset to the bottom dock."
+        else
+            python3 - <<'PY'
+import json, os
+p = os.path.expanduser("~/.config/handheld-kbd/config.json")
+try:
+    c = json.load(open(p))
+except Exception:
+    c = {}
+c["position_mode"] = "bottom"
+c.pop("geometry", None)
+os.makedirs(os.path.dirname(p), exist_ok=True)
+json.dump(c, open(p, "w"), indent=2)
+PY
+            echo "position reset; it applies next time the keyboard starts."
+        fi
+        ;;
+    *)
+        echo "usage: handheld-kbd-ctl [status|start|stop|restart|reset]" >&2
+        exit 2
+        ;;
+esac

--- a/bin/handheld-kbd-fix-pointer
+++ b/bin/handheld-kbd-fix-pointer
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Restore the Steam Deck's trackpad and stick pointer.
+#
+# The cause: while Steam believes its own on-screen keyboard is open, it forces the
+# controller into its "KB ActionSet", where the sticks and trackpads navigate that
+# keyboard instead of moving the desktop pointer. Steam's own log says so plainly:
+#
+#   Set OSK active 1 and appid 413080
+#   OnFocusWindowChanged On Screen Keyboard Forcing to window type: KB ActionSet
+#
+# Versions before 1.0.10 hid Steam's keyboard by setting its opacity to zero. The window
+# stayed mapped, so Steam went on believing its keyboard was open, and the Deck had no
+# pointer for as long as ours was up. Current versions close it instead.
+#
+# This is the cleanup for a session that is already stuck. It closes the leftover window,
+# which is all Steam needs to switch back to the desktop controller config — no restart,
+# and nothing else on the machine is disturbed.
+set -u
+NAME="Steam Input On-screen Keyboard"
+
+if ! command -v qdbus6 >/dev/null 2>&1; then
+    echo "!! qdbus6 not found — this needs KDE Plasma 6" >&2
+    exit 1
+fi
+
+JS=/tmp/handheld-kbd-close-steam-osk.js
+cat > "$JS" <<EOF
+var n = 0;
+workspace.windowList().forEach(function(w){
+    if (("" + w.caption).indexOf("$NAME") !== -1) { try { w.closeWindow(); n++; } catch(e){} }
+});
+print("HHKBD fix-pointer closed " + n + " Steam OSK window(s)");
+EOF
+
+echo ":: closing Steam's on-screen keyboard…"
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript hhkbd-close-osk >/dev/null 2>&1
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "$JS" hhkbd-close-osk >/dev/null 2>&1
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.start >/dev/null 2>&1
+sleep 1
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript hhkbd-close-osk >/dev/null 2>&1
+
+echo ":: done — the trackpad and stick pointer should work again."
+echo
+echo "   Still dead? Steam itself may have stopped: check with 'pgrep -c steamwebhelper'."
+echo "   Deliberately not restarting Steam here — a half-started Steam client leaves you"
+echo "   with no pointer at all, which is worse than the problem being fixed. Start it"
+echo "   from the launcher, or reboot."

--- a/bin/handheld-kbd-kwin-script
+++ b/bin/handheld-kbd-kwin-script
@@ -75,9 +75,12 @@ elif mode == "custom" and g.get("w") and g.get("h"):
 else:
     place = "dock"
 print(place, max(0.15, min(frac, 0.95)),
-      int(g.get("x", 0)), int(g.get("y", 0)), int(g.get("w", 0)), int(g.get("h", 0)))' 2>/dev/null)
+      int(g.get("x", 0)), int(g.get("y", 0)), int(g.get("w", 0)), int(g.get("h", 0)),
+      1 if d.get("kwin_focus_restore", True) else 0,
+      1 if d.get("kwin_fullscreen_lift", True) else 0)' 2>/dev/null)
 set -- $DOCK_CFG
 PLACE="${1:-dock}"; FRAC="${2:-0.42}"; CX="${3:-0}"; CY="${4:-0}"; CW="${5:-0}"; CH="${6:-0}"
+FOCUS="${7:-1}"; LIFT="${8:-1}"
 # An explicit --dock wins: free-move has to turn docking off even though the config still
 # says "bottom", or the keyboard is dragged straight back the moment the user lets go.
 # --dock 0 means the user is dragging: no placement at all until they finish.
@@ -101,9 +104,13 @@ for v in CX CY CW CH; do
 done
 
 if [ "$HIDE_STEAM" = 1 ]; then
+    # Transparent, not merely lowered: it must not flash on screen in the moment
+    # between mapping and us closing it.
     STEAM_RULE="else if (cap.indexOf(\"$NAME\") !== -1) w.opacity = 0.0;"
+    CLOSE_STEAM=1
 else
     STEAM_RULE="// Steam's OSK left alone: this keyboard has not proven it can appear yet."
+    CLOSE_STEAM=0
 fi
 
 [ "$OUT" = "/dev/stdout" ] || mkdir -p "$(dirname "$OUT")"
@@ -119,6 +126,19 @@ var REPORT = $REPORT;   // 1 = tell the keyboard where it ends up (free-move is 
 var PLACE = "$PLACE";  // "dock" | "custom" | "none" (the user is moving it by hand)
 var FRAC = $FRAC;      // dock height as a fraction of the usable area
 var CUSTOM = { x: $CX, y: $CY, width: $CW, height: $CH };
+// Everything below runs inside the compositor's own thread, so each of these is optional:
+// if a device turns out to be unhappy with us touching focus or stacking, it can be turned
+// off in config.json (kwin_focus_restore / kwin_fullscreen_lift) without losing the
+// keyboard itself, which only needs opacity, the mirror trigger and placement.
+var FOCUS_RESTORE = $FOCUS;
+var FULLSCREEN_LIFT = $LIFT;
+// Close Steam's on-screen keyboard rather than just hiding it. While Steam believes its
+// OSK is open it forces the controller into its "KB ActionSet", where the sticks and
+// trackpads navigate that keyboard instead of moving the desktop pointer — so a Steam
+// Deck loses its trackpad and stick mouse for as long as the window exists, even at
+// zero opacity, and only gets them back when Steam restarts. Closing the window makes
+// Steam set OSK-active back to 0 and reload the desktop controller config.
+var CLOSE_STEAM = $CLOSE_STEAM;
 var demoted = {};   // internalId -> true : fullscreen windows WE dropped to keepBelow
 var lastReal = null;   // most recent focusable window the user was on (for focus restore)
 
@@ -156,6 +176,7 @@ function kbdShown(){
 // activeFullScreen, so dropping the fullscreen window to keepBelow (BelowLayer)
 // lets the OSK float on top. Restore it when the OSK hides / leaves fullscreen.
 function applyStack(){
+    if (!FULLSCREEN_LIFT) return;
     try {
         var shown = kbdShown();
         var list = workspace.windowList();
@@ -269,31 +290,57 @@ function watchGeometry(w){
     // emits no signal we still hold a value — the pre-drag dock position — and finishing
     // the move would "save" that and snap the keyboard back to the dock.
 }
+// Steam's OSK opening is the hardware keyboard button being pressed. Deal with it:
+// summon or dismiss ours, then get Steam's out of the way for real.
+//
+// Closing it means Steam no longer tells us when the button is pressed a second time —
+// it just opens a fresh OSK — so the button has to toggle here rather than relying on
+// Steam's own show/hide. The guard is against Steam re-mapping the window on its way
+// out, which would otherwise read as a second press and immediately undo the first.
+var lastSteamOsk = 0;
+function onSteamOsk(w){
+    var now = new Date().getTime();
+    if (now - lastSteamOsk < 700) { if (CLOSE_STEAM) closeSteamOsk(w); return; }
+    lastSteamOsk = now;
+    callKbd(CLOSE_STEAM ? "Toggle" : "Show");
+    if (CLOSE_STEAM) closeSteamOsk(w);
+}
+
+function closeSteamOsk(w){
+    try { w.closeWindow(); } catch(e){}
+}
+
 function onAdded(w){
     setOp(w); watch(w); dockKbd(w); applyStack();
-    if (MIRROR && isSteamOsk(w)) callKbd("Show");
+    if (MIRROR && isSteamOsk(w)) onSteamOsk(w);
     // When our OSK maps, the summon (touch gesture / map) may have shifted focus.
     // Re-assert the window the user was on so typed keys land there. keepBelow keeps
     // a demoted fullscreen window below the OSK even once it is active again.
-    if (isKbd(w) && lastReal) {
+    if (FOCUS_RESTORE && isKbd(w) && lastReal) {
         // only re-activate if focus actually moved, so we don't needlessly re-raise the
         // window and disturb the text caret when the summon didn't defocus it.
         try { if (workspace.activeWindow !== lastReal) workspace.activeWindow = lastReal; } catch(e){}
     }
 }
 
-workspace.windowActivated.connect(function(w){ if (focusable(w)) lastReal = w; });
+if (FOCUS_RESTORE) workspace.windowActivated.connect(function(w){ if (focusable(w)) lastReal = w; });
 workspace.windowList().forEach(function(w){
     setOp(w); watch(w);
     // Existing windows: in custom placement, mark as already placed so a script reload
     // leaves them untouched. Docking still re-asserts, because that is ours to compute.
     if (PLACE === "custom") placedCustom[""+w.internalId] = true;
     dockKbd(w);
+    // A Steam OSK left over from before this script loaded is still holding the
+    // controller in KB ActionSet. Close it on sight — this is what gives a Deck its
+    // trackpad and stick pointer back without restarting Steam.
+    if (MIRROR && CLOSE_STEAM && isSteamOsk(w)) closeSteamOsk(w);
 });
 workspace.windowAdded.connect(onAdded);
 workspace.windowRemoved.connect(function(w){
     applyStack();
-    if (MIRROR && isSteamOsk(w)) callKbd("Hide");
+    // Only mirror the close when we are not the ones closing it — otherwise our own
+    // closeWindow() would hide the keyboard we just summoned.
+    if (MIRROR && !CLOSE_STEAM && isSteamOsk(w)) callKbd("Hide");
 });
 applyStack();
 EOF

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,8 @@ install -m755 "$HERE/bin/handheld-kbd-recover"   "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-dock-rect" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-install-filter" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-toggle" "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-ctl" "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-fix-pointer" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-build-dict" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-focus-probe" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-resume.sh"  "$BIN/"
@@ -202,6 +204,18 @@ sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd.desktop"      > "$AUTO/hand
 sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd-swap.desktop" > "$AUTO/handheld-kbd-swap.desktop"
 sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd-resume.desktop"   > "$AUTO/handheld-kbd-resume.desktop"
 chmod 644 "$AUTO/handheld-kbd.desktop" "$AUTO/handheld-kbd-swap.desktop" "$AUTO/handheld-kbd-resume.desktop"
+
+# --- application-menu shortcuts (show/hide, restart, stop, reset position) ---
+# Typing a command is the one thing you can't do when the keyboard is the problem,
+# so every recovery action is also a thing you can click.
+APPS="$HOME/.local/share/applications"
+mkdir -p "$APPS"
+for s in "$HERE"/shortcuts/*.desktop; do
+  [ -f "$s" ] || continue
+  sed "s#__BIN__#$BIN#g" "$s" > "$APPS/$(basename "$s")"
+  chmod 644 "$APPS/$(basename "$s")"
+done
+command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$APPS" 2>/dev/null
 
 # --- KWin window rule (pins the keyboard: on top, no focus-steal, bottom-docked) ---
 if command -v kwriteconfig6 >/dev/null 2>&1; then

--- a/shortcuts/handheld-kbd-fix-pointer.desktop
+++ b/shortcuts/handheld-kbd-fix-pointer.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Fix Trackpad and Stick Pointer
+Comment=Close Steam's leftover on-screen keyboard, which holds the controller in keyboard mode
+Icon=input-touchpad
+Terminal=false
+Exec=__BIN__/handheld-kbd-fix-pointer
+Categories=Utility;Accessibility;
+Keywords=trackpad;pointer;mouse;stick;steam;

--- a/shortcuts/handheld-kbd-reset.desktop
+++ b/shortcuts/handheld-kbd-reset.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Reset Keyboard Position
+Comment=Put the keyboard back on the bottom dock at its default size
+Icon=go-bottom
+Terminal=false
+Exec=__BIN__/handheld-kbd-ctl reset
+Categories=Utility;Accessibility;
+Keywords=keyboard;reset;position;dock;

--- a/shortcuts/handheld-kbd-restart.desktop
+++ b/shortcuts/handheld-kbd-restart.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Restart Handheld Keyboard
+Comment=Stop and start the keyboard — the usual fix when it stops responding
+Icon=view-refresh
+Terminal=false
+Exec=__BIN__/handheld-kbd-ctl restart
+Categories=Utility;Accessibility;
+Keywords=keyboard;restart;reload;

--- a/shortcuts/handheld-kbd-stop.desktop
+++ b/shortcuts/handheld-kbd-stop.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Stop Handheld Keyboard
+Comment=Shut the keyboard down until you start it again or log back in
+Icon=process-stop
+Terminal=false
+Exec=__BIN__/handheld-kbd-ctl stop
+Categories=Utility;Accessibility;
+Keywords=keyboard;stop;kill;quit;

--- a/shortcuts/handheld-kbd-toggle.desktop
+++ b/shortcuts/handheld-kbd-toggle.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Handheld Keyboard
+GenericName=On-screen keyboard
+Comment=Show or hide the keyboard without going through Steam
+Icon=input-keyboard
+Terminal=false
+Exec=__BIN__/handheld-kbd-toggle
+Categories=Utility;Accessibility;
+Keywords=keyboard;osk;onscreen;

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -14,8 +14,12 @@ rm -f "$HOME/.local/bin/handheld-kbd.py" \
       "$HOME/.local/bin/handheld-kbd-swap.sh" \
       "$HOME/.local/bin/handheld-kbd-relogin" \
       "$HOME/.local/bin/handheld-kbd-ip-remap" \
+      "$HOME/.local/bin/handheld-kbd-ctl" \
       "$HOME/.config/autostart/handheld-kbd.desktop" \
       "$HOME/.config/autostart/handheld-kbd-swap.desktop"
+rm -f "$HOME"/.local/share/applications/handheld-kbd-*.desktop
+command -v update-desktop-database >/dev/null 2>&1 && \
+  update-desktop-database "$HOME/.local/share/applications" 2>/dev/null
 rm -rf "$HOME/.local/share/kwin/scripts/handheld-kbd-opacity"
 
 # restore the hardware keyboard button (we remapped it via InputPlumber)


### PR DESCRIPTION
## The bug

On a Steam Deck the keyboard is summoned by Steam's own on-screen keyboard appearing, and we hid Steam's by setting its opacity to zero. The window stayed mapped, so Steam went on believing its keyboard was open — and while it believes that, it forces the controller into its "KB ActionSet", where the sticks and trackpads navigate *that* keyboard instead of moving the desktop pointer.

Steam says so in its own log:

```
Set OSK active 1 and appid 413080
OnFocusWindowChanged On Screen Keyboard Forcing to window type: KB ActionSet, AppID 769
```

So you got a keyboard usable only by touch, and no pointer at all until Steam restarted. That is exactly #14.

It never affected a Legion Go, where the hardware button is remapped through InputPlumber and Steam's keyboard is never involved — which is why it looked device-specific for so long.

Ruled out along the way, with measurements rather than guesses: `/dev/uinput` device identity, KWin focus restore, fullscreen lifting, and XTEST pointer injection — XTEST moved the cursor correctly in every keyboard state, so the pointer path was never broken. Steam had simply stopped driving it.

## The fix

- Close Steam's keyboard rather than hide it. Steam sets OSK-active back to 0 and reloads the desktop controller config.
- The hardware button is handled as a toggle in the compositor, since Steam no longer reports the second press as a close. 700 ms guard against Steam re-mapping the window on its way out.
- Loading the KWin script closes any keyboard left over from a previous session, so a stuck Deck recovers with no Steam restart.
- `handheld-kbd-fix-pointer` does only that close now. Restarting Steam sometimes left it half-started — no pointer at all, worse than the problem.

## Also

- `handheld-kbd-ctl` — `status`, `start`, `stop`, `restart`, `reset`, all idempotent. Starts the supervisor under the user service manager, so a keyboard started over SSH gets a display and a session bus instead of coming up mute.
- Application-menu shortcuts for show/hide, restart, stop, reset position and fix-pointer. Typing a command is the one thing you can't do when the keyboard is the problem.
- `uninstall.sh` removes both.

Verified on a Steam Deck OLED: three simulated Steam-OSK presses toggled the keyboard show → hide → show, with Steam's window closed each time.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)