### PR TITLE
Key labels for twenty layouts, plus AltGr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,25 @@ jobs:
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
           # The section runs from its own '## v<version>' heading to the next '## ' heading.
-          awk -v v="$version" '
-            $0 ~ "^## v" v "([^0-9.]|$)" { found = 1; sub(/^## /, ""); title = $0; next }
-            found && /^## / { exit }
-            found { print }
-          ' CHANGELOG.md > notes.md
-          title=$(awk -v v="$version" '$0 ~ "^## v" v "([^0-9.]|$)" { sub(/^## /, ""); print; exit }' CHANGELOG.md)
+          notes() {
+            awk -v v="$1" '
+              $0 ~ "^## v" v "([^0-9.]|$)" { found = 1; next }
+              found && /^## / { exit }
+              found { print }
+            ' CHANGELOG.md
+          }
+          heading() {
+            awk -v v="$1" '$0 ~ "^## v" v "([^0-9.]|$)" { sub(/^## /, ""); print; exit }' CHANGELOG.md
+          }
+          notes "$version" > notes.md
+          title=$(heading "$version")
+          # A pre-release tag (v1.2.3-rc1) documents the version it is a candidate for, so
+          # fall back to that section rather than demanding a heading per candidate.
+          if [ ! -s notes.md ] && [ "$version" != "${version%%-*}" ]; then
+            version="${version%%-*}"
+            notes "$version" > notes.md
+            title=$(heading "$version")
+          fi
           if [ ! -s notes.md ] || [ -z "$title" ]; then
             echo "::error::CHANGELOG.md has no '## v$version' section — add one before tagging."
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ raw/
 
 # bundled at release time by the workflow, never committed
 vendor/
+
+# fetched by tools/build-locales.py, not source
+tools/.xkb/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
+## v1.0.11 — Twenty languages
+
+Pre-release. The mechanism is tested; the individual layouts are not — I read Latin
+scripts and can spot-check Cyrillic and Greek, and that is the end of my usefulness as a
+proofreader for Arabic, Hebrew, Devanagari and Thai. Corrections very welcome.
+
+### Added
+
+- **Key labels for twenty XKB layouts.** English (US/UK), German, French, Spanish (Spain
+  and Latin America), Italian, Portuguese (Portugal and Brazil), Dutch, Polish, Turkish,
+  Russian, Ukrainian, Greek, Arabic, Hebrew, Hindi (Devanagari), Thai and Vietnamese.
+  🌐 switches between the layouts KDE has configured and re-skins the keys to match.
+
+  These are *labels*, not behaviour. The keyboard injects real keycodes, so what a key
+  types was always decided by the OS layout — what was missing is the keyboard admitting
+  it, by drawing `й` on the key that types `й` instead of `q`. A layout with no labels
+  still works; it is just drawn with US captions.
+
+  They are generated from [xkeyboard-config](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config)
+  and xorgproto's `keysymdef.h` by `tools/build-locales.py`, and committed. Typing them
+  out by hand would have been twenty chances to be subtly wrong in scripts I cannot
+  proofread.
+
+- **AltGr.** Most non-English layouts keep a third of their characters on the third level
+  — Polish `ą`, French `@`, Turkish `î`, Italian `[` — and without an AltGr key they were
+  simply unreachable. Holding it re-skins the keys to show what they will type, rather
+  than printing three glyphs on a key the size of a fingernail. Existing installs get the
+  key added to their layout on upgrade.
+
+- **`handheld-kbd-locales`** — list, add, remove or set the layouts KDE offers, since
+  🌐 can only reach layouts KDE has been told about, and with one configured it has
+  nowhere to go. Reports which have labels and which don't, and reminds you that KDE
+  reads its layout list at session start.
+
+### Notes on what this can't do
+
+- **Chinese, Japanese and Korean are absent and will stay absent.** They are input methods,
+  not keyboard layouts; no mapping of keycodes to characters produces them. Fcitx and IBus
+  work with this keyboard exactly as with any other, because the keystrokes are real.
+- **Vietnamese is a halfway case.** The `vn` layout puts `ă â ê ô ơ ư đ` on the number row
+  and tone marks on `5`–`9` — which costs you the digits and still cannot produce every
+  syllable. Most Vietnamese typing uses an IME (Telex/VNI) over a US layout. That works
+  here; the layout is shipped for those who want it.
+
 ## v1.0.10 — The Steam Deck keeps its trackpads
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,8 +27,13 @@ So I built the keyboard I wanted instead. Here's what it does differently:
   behind it.
 - **It's mine to theme, and yours too.** Layout, colours, key sizes, and opacity
   all live in a JSON file. No code to touch.
-- **US / UK layouts.** A 🌐 key flips the layout so `£`, `@`, `#`, `"` land where
-  they should.
+- **Twenty layouts.** English (US/UK), German, French, Spanish (Spain and Latin
+  America), Italian, Portuguese (Portugal and Brazil), Dutch, Polish, Turkish,
+  Russian, Ukrainian, Greek, Arabic, Hebrew, Hindi, Thai and Vietnamese. The 🌐 key
+  switches between the ones you've configured and re-skins the keys, so `£`, `ñ`, `ç`,
+  `й` and `ก` are drawn where they actually are. `handheld-kbd-locales` picks which.
+- **AltGr.** Most layouts keep a third of their alphabet behind it — Polish `ą`, French
+  `@`, Turkish `î`. Hold it and the keys show what they'll type.
 - **Predictive text.** A row of tappable suggestions above the keys. It learns
   what *you* type, and `handheld-kbd-build-dict` adds corpus frequencies so it's
   useful from the first keypress. Tapping a suggestion types it as real keys, so
@@ -147,6 +152,38 @@ vocabulary, stays on the device, and is in `.gitignore` for a reason.
 
 Turn learning off with `"predict_learn": false` (corpus only), or prediction entirely
 with `"prediction": false`.
+
+## Languages
+
+```bash
+handheld-kbd-locales                # what's configured, and what labels exist
+handheld-kbd-locales add it vn      # Italian and Vietnamese
+handheld-kbd-locales set us ru      # replace the list
+```
+
+Then log out and back in — KDE reads its layout list at session start — and 🌐 cycles
+through them.
+
+Worth knowing how this works, because it explains what it can and can't do. The keyboard
+injects real keycodes, exactly like a USB keyboard; **what a key types is decided by the
+OS layout**, not by this program. So a locale file here contains no behaviour at all, only
+the labels to paint on the keys. They're generated from
+[xkeyboard-config](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config) — the
+same data the OS uses — by `tools/build-locales.py`, rather than typed out by hand in
+scripts most of us can't proofread.
+
+Two consequences:
+
+- **A layout with no labels still works.** It types correctly; the keys are just drawn
+  with US captions. Any of the hundreds of layouts KDE offers can be added.
+- **Chinese, Japanese and Korean aren't here, and can't be.** Those are input methods, not
+  keyboard layouts — no mapping of keycodes to characters produces them. Use Fcitx or
+  IBus; this keyboard's keystrokes reach it like any other keyboard's.
+
+Vietnamese is a halfway case worth calling out. The `vn` layout puts `ă â ê ô ơ ư đ` on
+the number row and tone marks on `5`–`9`, which costs you the digits and can't produce
+every syllable. Most Vietnamese typing is done with an IME (Telex or VNI) on a US layout
+instead — that works here too, and is probably what you want.
 
 ## Configure
 

--- a/bin/handheld-kbd-locales
+++ b/bin/handheld-kbd-locales
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Choose which keyboard layouts the 🌐 key cycles through.
+
+The keyboard injects real keycodes, so what a key TYPES is decided by the OS layout, not
+by us. 🌐 asks KDE to switch to its next layout and then re-skins the keys to match. That
+means it can only reach layouts KDE has been told about — with one layout configured,
+🌐 has nowhere to go.
+
+This edits KDE's layout list for you, and reports which of them this keyboard has key
+labels for.
+
+    handheld-kbd-locales                list what is configured, and what is available
+    handheld-kbd-locales add it vn      add Italian and Vietnamese
+    handheld-kbd-locales remove vn      remove Vietnamese
+    handheld-kbd-locales set us it ru   replace the list outright
+
+KDE reads this list when the session starts, so a change needs a log out and back in
+before 🌐 can reach the new layouts. You are told when that applies.
+
+Chinese, Japanese and Korean are not here, and can't be: they are input methods rather
+than keyboard layouts, and no mapping of keycodes to characters produces them. Use
+Fcitx or IBus for those — this keyboard's keystrokes go to it like any other keyboard's.
+"""
+import json
+import os
+import subprocess
+import sys
+
+CFG_DIR = os.path.expanduser("~/.config/handheld-kbd")
+SHIPPED = os.path.join(CFG_DIR, "locales")
+BOLD, DIM, GREEN, YELLOW, RESET = "\033[1m", "\033[2m", "\033[32m", "\033[33m", "\033[0m"
+
+
+def available():
+    """{code: language name} for the layouts we ship labels for."""
+    try:
+        with open(os.path.join(SHIPPED, "index.json")) as f:
+            return json.load(f)
+    except Exception:
+        return {os.path.splitext(n)[0]: "" for n in sorted(os.listdir(SHIPPED))
+                if n.endswith(".json") and n != "index.json"}
+
+
+def kread(key, default=""):
+    try:
+        return subprocess.check_output(
+            ["kreadconfig6", "--file", "kxkbrc", "--group", "Layout", "--key", key],
+            text=True, timeout=5).strip()
+    except Exception:
+        return default
+
+
+def kwrite(key, value):
+    subprocess.run(["kwriteconfig6", "--file", "kxkbrc", "--group", "Layout",
+                    "--key", key, value], check=True, timeout=5)
+
+
+def configured():
+    return [c for c in kread("LayoutList").split(",") if c.strip()]
+
+
+def write_layouts(codes):
+    # DisplayNames and VariantList are positional: leaving stale entries behind gives the
+    # wrong label, or the wrong variant, for every layout after the one that changed.
+    kwrite("LayoutList", ",".join(codes))
+    kwrite("VariantList", ",".join("" for _ in codes))
+    kwrite("DisplayNames", ",".join("" for _ in codes))
+    kwrite("Use", "true")
+    if len(codes) > 1:
+        kwrite("SwitchMode", "Global")
+
+
+def show():
+    avail, have = available(), configured()
+    print(f"{BOLD}Configured in KDE{RESET} (🌐 cycles these, in order)")
+    if have:
+        for c in have:
+            name = avail.get(c)
+            mark = f"{GREEN}labels{RESET}" if c in avail else f"{YELLOW}no labels{RESET}"
+            print(f"  {c:6s} {mark:22s} {name or ''}")
+    else:
+        print(f"  {DIM}(none — KDE has no layout list set){RESET}")
+    if len(have) < 2:
+        print(f"\n  {YELLOW}Only one layout: 🌐 has nowhere to switch to.{RESET}"
+              f" Add one with 'handheld-kbd-locales add <code>'.")
+    print(f"\n{BOLD}Labels available{RESET}")
+    for code, name in sorted(avail.items()):
+        here = "•" if code in have else " "
+        print(f"  {here} {code:6s} {name}")
+    print(f"\n{DIM}A layout with no labels still works — the keys type correctly, they are"
+          f"\njust drawn with US captions.{RESET}")
+
+
+def apply(codes, verb):
+    avail = available()
+    unknown = [c for c in codes if c not in avail]
+    write_layouts(codes)
+    print(f"{GREEN}::{RESET} {verb}: {', '.join(codes) if codes else '(empty)'}")
+    if unknown:
+        print(f"{YELLOW}!!{RESET} no key labels for: {', '.join(unknown)} — they will type"
+              f" correctly but be drawn with US captions.")
+    print(f"{YELLOW}!!{RESET} Log out and back in — KDE reads its layout list at session start.")
+
+
+def main():
+    argv = sys.argv[1:]
+    if not argv or argv[0] in ("list", "show", "-l"):
+        show()
+        return 0
+    cmd, codes = argv[0], [c.strip().lower() for c in argv[1:] if c.strip()]
+    if cmd in ("-h", "--help", "help"):
+        print(__doc__)
+        return 0
+    if cmd not in ("add", "remove", "rm", "set"):
+        print(f"usage: handheld-kbd-locales [list|add|remove|set] [codes…]", file=sys.stderr)
+        return 2
+    if not codes:
+        print(f"handheld-kbd-locales {cmd}: needs at least one layout code", file=sys.stderr)
+        return 2
+
+    have = configured() or ["us"]
+    if cmd == "add":
+        new = have + [c for c in codes if c not in have]
+        if new == have:
+            print(f"{DIM}already configured: {', '.join(codes)}{RESET}")
+            return 0
+        apply(new, "layouts")
+    elif cmd in ("remove", "rm"):
+        new = [c for c in have if c not in codes]
+        if not new:
+            print("refusing to remove every layout — KDE needs at least one", file=sys.stderr)
+            return 1
+        if new == have:
+            print(f"{DIM}not configured: {', '.join(codes)}{RESET}")
+            return 0
+        apply(new, "layouts")
+    else:
+        apply(codes, "layouts set to")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except FileNotFoundError as ex:
+        print(f"handheld-kbd-locales: {ex} — this needs KDE Plasma 6", file=sys.stderr)
+        sys.exit(1)

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -692,12 +692,28 @@ class OSK(Gtk.Window):
     def apply_locale(self, code):
         """Re-skin key labels to match the active XKB layout."""
         self.locale = code
-        lmap = load_locale_map(code)
-        for (b, name, base_label, base_shifted) in self.keybtns:
-            ov = lmap.get(name, {})
-            self._set_label(b, ov.get("label", base_label), ov.get("shifted", base_shifted))
+        self.lmap = load_locale_map(code)
+        self._relabel()
         if self.locale_btn:
             self._set_label(self.locale_btn, "🌐" + code.upper(), "")
+
+    def _relabel(self):
+        """Paint the keys for the current layout and modifier state.
+
+        With AltGr held the keys show their third level instead of their first. Printing
+        all three at once was the alternative, and on a 7-inch panel three glyphs per key
+        is unreadable — and most layouts have an AltGr symbol on nearly every key. Showing
+        the level you are actually about to type is both clearer and smaller.
+        """
+        lmap = getattr(self, "lmap", {}) or {}
+        alt_held = e.KEY_RIGHTALT in self.mods
+        for (b, name, base_label, base_shifted) in self.keybtns:
+            ov = lmap.get(name, {})
+            if alt_held and ov.get("alt"):
+                self._set_label(b, ov["alt"], "")
+            else:
+                self._set_label(b, ov.get("label", base_label),
+                                ov.get("shifted", base_shifted))
 
     def on_locale(self, btn):
         if self._stray_tap():
@@ -1242,6 +1258,8 @@ class OSK(Gtk.Window):
         if kc in self.mods: del self.mods[kc]
         else: self.mods[kc] = True
         self._refresh_mods()
+        if kc == e.KEY_RIGHTALT:
+            self._relabel()
 
     def _stray_tap(self):
         """True just after a swipe ends: GTK may still deliver a click for the key the
@@ -1259,7 +1277,10 @@ class OSK(Gtk.Window):
         self.ui.write(e.EV_KEY, kc, 0); self.ui.syn(); time.sleep(s)
         for m in reversed(mods): self.ui.write(e.EV_KEY, m, 0)
         if mods: self.ui.syn()
+        had_alt = e.KEY_RIGHTALT in mods
         self.mods.clear(); self._refresh_mods()
+        if had_alt:
+            self._relabel()          # the third level is spent; go back to showing the first
         self._track(kc, mods)
 
     def dismiss(self):

--- a/config/layouts/compact.json
+++ b/config/layouts/compact.json
@@ -279,6 +279,11 @@
         "kind": "mod"
       },
       {
+        "label": "AltGr",
+        "key": "KEY_RIGHTALT",
+        "kind": "mod"
+      },
+      {
         "label": "Space",
         "key": "KEY_SPACE",
         "kind": "space"
@@ -298,6 +303,10 @@
       {
         "label": "→",
         "key": "KEY_RIGHT"
+      },
+      {
+        "label": "🌐",
+        "kind": "locale"
       }
     ]
   ]

--- a/config/layouts/full.json
+++ b/config/layouts/full.json
@@ -333,6 +333,11 @@
         "kind": "mod"
       },
       {
+        "label": "AltGr",
+        "key": "KEY_RIGHTALT",
+        "kind": "mod"
+      },
+      {
         "label": "Space",
         "key": "KEY_SPACE",
         "kind": "space"

--- a/config/locales/ara.json
+++ b/config/locales/ara.json
@@ -1,0 +1,183 @@
+{
+  "KEY_0": {
+    "alt": "٠",
+    "label": "0",
+    "shifted": "("
+  },
+  "KEY_1": {
+    "alt": "١",
+    "label": "1",
+    "shifted": "!"
+  },
+  "KEY_2": {
+    "alt": "٢",
+    "label": "2",
+    "shifted": "@"
+  },
+  "KEY_3": {
+    "alt": "٣",
+    "label": "3",
+    "shifted": "#"
+  },
+  "KEY_4": {
+    "alt": "٤",
+    "label": "4",
+    "shifted": "$"
+  },
+  "KEY_5": {
+    "alt": "٥",
+    "label": "5",
+    "shifted": "%"
+  },
+  "KEY_6": {
+    "alt": "٦",
+    "label": "6",
+    "shifted": "^"
+  },
+  "KEY_7": {
+    "alt": "٧",
+    "label": "7",
+    "shifted": "&"
+  },
+  "KEY_8": {
+    "alt": "٨",
+    "label": "8",
+    "shifted": "*"
+  },
+  "KEY_9": {
+    "alt": "٩",
+    "label": "9",
+    "shifted": ")"
+  },
+  "KEY_A": {
+    "label": "ش",
+    "shifted": "ِ"
+  },
+  "KEY_APOSTROPHE": {
+    "alt": "⟩",
+    "label": "ط",
+    "shifted": "\""
+  },
+  "KEY_BACKSLASH": {
+    "alt": "⟨",
+    "label": "\\",
+    "shifted": "|"
+  },
+  "KEY_C": {
+    "label": "ؤ",
+    "shifted": "}"
+  },
+  "KEY_D": {
+    "label": "ي",
+    "shifted": "]"
+  },
+  "KEY_E": {
+    "label": "ث",
+    "shifted": "ُ"
+  },
+  "KEY_EQUAL": {
+    "alt": "≠",
+    "label": "=",
+    "shifted": "+"
+  },
+  "KEY_F": {
+    "alt": "پ",
+    "label": "ب",
+    "shifted": "["
+  },
+  "KEY_G": {
+    "label": "ل",
+    "shifted": "ﻷ"
+  },
+  "KEY_GRAVE": {
+    "alt": "٪",
+    "label": "ذ",
+    "shifted": "ّ"
+  },
+  "KEY_H": {
+    "alt": "ٱ",
+    "label": "ا",
+    "shifted": "أ"
+  },
+  "KEY_I": {
+    "label": "ه",
+    "shifted": "÷"
+  },
+  "KEY_J": {
+    "label": "ت",
+    "shifted": "ـ"
+  },
+  "KEY_K": {
+    "alt": "٫",
+    "label": "ن",
+    "shifted": "،"
+  },
+  "KEY_L": {
+    "label": "م",
+    "shifted": "/"
+  },
+  "KEY_LEFTBRACE": {
+    "alt": "چ",
+    "label": "ج",
+    "shifted": "<"
+  },
+  "KEY_MINUS": {
+    "alt": "–",
+    "label": "-",
+    "shifted": "_"
+  },
+  "KEY_O": {
+    "label": "خ",
+    "shifted": "×"
+  },
+  "KEY_P": {
+    "label": "ح",
+    "shifted": "؛"
+  },
+  "KEY_Q": {
+    "label": "ض",
+    "shifted": "َ"
+  },
+  "KEY_R": {
+    "label": "ق",
+    "shifted": "ٌ"
+  },
+  "KEY_RIGHTBRACE": {
+    "label": "د",
+    "shifted": ">"
+  },
+  "KEY_S": {
+    "label": "س",
+    "shifted": "ٍ"
+  },
+  "KEY_SEMICOLON": {
+    "alt": "گ",
+    "label": "ك",
+    "shifted": ":"
+  },
+  "KEY_T": {
+    "alt": "ڤ",
+    "label": "ف",
+    "shifted": "ﻹ"
+  },
+  "KEY_U": {
+    "label": "ع",
+    "shifted": "`"
+  },
+  "KEY_W": {
+    "label": "ص",
+    "shifted": "ً"
+  },
+  "KEY_X": {
+    "label": "ء",
+    "shifted": "ْ"
+  },
+  "KEY_Y": {
+    "label": "غ",
+    "shifted": "إ"
+  },
+  "KEY_Z": {
+    "label": "ئ",
+    "shifted": "~"
+  }
+}

--- a/config/locales/br.json
+++ b/config/locales/br.json
@@ -12,27 +12,27 @@
   "KEY_2": {
     "alt": "²",
     "label": "2",
-    "shifted": "\""
+    "shifted": "@"
   },
   "KEY_3": {
     "alt": "³",
     "label": "3",
-    "shifted": "£"
+    "shifted": "#"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "£",
     "label": "4",
     "shifted": "$"
   },
   "KEY_5": {
-    "alt": "½",
+    "alt": "¢",
     "label": "5",
     "shifted": "%"
   },
   "KEY_6": {
-    "alt": "¾",
+    "alt": "¬",
     "label": "6",
-    "shifted": "^"
+    "shifted": "¨"
   },
   "KEY_7": {
     "alt": "{",
@@ -54,21 +54,20 @@
     "label": "a"
   },
   "KEY_APOSTROPHE": {
-    "alt": "ˆ",
-    "label": "'",
-    "shifted": "@"
+    "alt": "~",
+    "label": "˜",
+    "shifted": "ˆ"
   },
   "KEY_B": {
     "alt": "“",
     "label": "b"
   },
   "KEY_BACKSLASH": {
-    "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "label": "]",
+    "shifted": "}"
   },
   "KEY_C": {
-    "alt": "¢",
+    "alt": "©",
     "label": "c"
   },
   "KEY_COMMA": {
@@ -86,10 +85,11 @@
     "shifted": ">"
   },
   "KEY_E": {
+    "alt": "°",
     "label": "e"
   },
   "KEY_EQUAL": {
-    "alt": "¸",
+    "alt": "§",
     "label": "=",
     "shifted": "+"
   },
@@ -102,9 +102,9 @@
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
-    "label": "`",
-    "shifted": "¬"
+    "alt": "¬",
+    "label": "'",
+    "shifted": "\""
   },
   "KEY_H": {
     "alt": "ħ",
@@ -127,9 +127,8 @@
     "label": "l"
   },
   "KEY_LEFTBRACE": {
-    "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "label": "´",
+    "shifted": "`"
   },
   "KEY_M": {
     "alt": "µ",
@@ -153,17 +152,17 @@
     "label": "p"
   },
   "KEY_Q": {
-    "alt": "@",
+    "alt": "/",
     "label": "q"
   },
   "KEY_R": {
-    "alt": "¶",
+    "alt": "®",
     "label": "r"
   },
   "KEY_RIGHTBRACE": {
-    "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "alt": "ª",
+    "label": "[",
+    "shifted": "{"
   },
   "KEY_S": {
     "alt": "ß",
@@ -171,13 +170,12 @@
   },
   "KEY_SEMICOLON": {
     "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "label": "ç"
   },
   "KEY_SLASH": {
     "alt": "◌̣",
-    "label": "/",
-    "shifted": "?"
+    "label": ";",
+    "shifted": ":"
   },
   "KEY_T": {
     "alt": "ŧ",
@@ -192,7 +190,7 @@
     "label": "v"
   },
   "KEY_W": {
-    "alt": "ſ",
+    "alt": "?",
     "label": "w"
   },
   "KEY_X": {

--- a/config/locales/de.json
+++ b/config/locales/de.json
@@ -2,7 +2,7 @@
   "KEY_0": {
     "alt": "}",
     "label": "0",
-    "shifted": ")"
+    "shifted": "="
   },
   "KEY_1": {
     "alt": "¹",
@@ -17,10 +17,10 @@
   "KEY_3": {
     "alt": "³",
     "label": "3",
-    "shifted": "£"
+    "shifted": "§"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "¼",
     "label": "4",
     "shifted": "$"
   },
@@ -30,24 +30,24 @@
     "shifted": "%"
   },
   "KEY_6": {
-    "alt": "¾",
+    "alt": "¬",
     "label": "6",
-    "shifted": "^"
+    "shifted": "&"
   },
   "KEY_7": {
     "alt": "{",
     "label": "7",
-    "shifted": "&"
+    "shifted": "/"
   },
   "KEY_8": {
     "alt": "[",
     "label": "8",
-    "shifted": "*"
+    "shifted": "("
   },
   "KEY_9": {
     "alt": "]",
     "label": "9",
-    "shifted": "("
+    "shifted": ")"
   },
   "KEY_A": {
     "alt": "æ",
@@ -55,43 +55,43 @@
   },
   "KEY_APOSTROPHE": {
     "alt": "ˆ",
-    "label": "'",
-    "shifted": "@"
+    "label": "ä"
   },
   "KEY_B": {
     "alt": "“",
     "label": "b"
   },
   "KEY_BACKSLASH": {
-    "alt": "`",
+    "alt": "’",
     "label": "#",
-    "shifted": "~"
+    "shifted": "'"
   },
   "KEY_C": {
     "alt": "¢",
     "label": "c"
   },
   "KEY_COMMA": {
-    "alt": "•",
+    "alt": "·",
     "label": ",",
-    "shifted": "<"
+    "shifted": ";"
   },
   "KEY_D": {
     "alt": "ð",
     "label": "d"
   },
   "KEY_DOT": {
-    "alt": "·",
+    "alt": "…",
     "label": ".",
-    "shifted": ">"
+    "shifted": ":"
   },
   "KEY_E": {
+    "alt": "€",
     "label": "e"
   },
   "KEY_EQUAL": {
     "alt": "¸",
-    "label": "=",
-    "shifted": "+"
+    "label": "´",
+    "shifted": "`"
   },
   "KEY_F": {
     "alt": "đ",
@@ -102,9 +102,9 @@
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
-    "label": "`",
-    "shifted": "¬"
+    "alt": "′",
+    "label": "ˆ",
+    "shifted": "°"
   },
   "KEY_H": {
     "alt": "ħ",
@@ -115,7 +115,7 @@
     "label": "i"
   },
   "KEY_J": {
-    "alt": "◌̉",
+    "alt": "◌̣",
     "label": "j"
   },
   "KEY_K": {
@@ -128,8 +128,7 @@
   },
   "KEY_LEFTBRACE": {
     "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "label": "ü"
   },
   "KEY_M": {
     "alt": "µ",
@@ -137,8 +136,8 @@
   },
   "KEY_MINUS": {
     "alt": "\\",
-    "label": "-",
-    "shifted": "_"
+    "label": "ß",
+    "shifted": "?"
   },
   "KEY_N": {
     "alt": "”",
@@ -161,23 +160,22 @@
     "label": "r"
   },
   "KEY_RIGHTBRACE": {
-    "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "alt": "~",
+    "label": "+",
+    "shifted": "*"
   },
   "KEY_S": {
-    "alt": "ß",
+    "alt": "ſ",
     "label": "s"
   },
   "KEY_SEMICOLON": {
-    "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "alt": "˝",
+    "label": "ö"
   },
   "KEY_SLASH": {
-    "alt": "◌̣",
-    "label": "/",
-    "shifted": "?"
+    "alt": "–",
+    "label": "-",
+    "shifted": "_"
   },
   "KEY_T": {
     "alt": "ŧ",
@@ -200,9 +198,9 @@
   },
   "KEY_Y": {
     "alt": "←",
-    "label": "y"
+    "label": "z"
   },
   "KEY_Z": {
-    "label": "z"
+    "label": "y"
   }
 }

--- a/config/locales/es.json
+++ b/config/locales/es.json
@@ -2,25 +2,25 @@
   "KEY_0": {
     "alt": "}",
     "label": "0",
-    "shifted": ")"
+    "shifted": "="
   },
   "KEY_1": {
-    "alt": "¹",
+    "alt": "|",
     "label": "1",
     "shifted": "!"
   },
   "KEY_2": {
-    "alt": "²",
+    "alt": "@",
     "label": "2",
     "shifted": "\""
   },
   "KEY_3": {
-    "alt": "³",
+    "alt": "#",
     "label": "3",
-    "shifted": "£"
+    "shifted": "·"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "~",
     "label": "4",
     "shifted": "$"
   },
@@ -30,42 +30,41 @@
     "shifted": "%"
   },
   "KEY_6": {
-    "alt": "¾",
+    "alt": "¬",
     "label": "6",
-    "shifted": "^"
+    "shifted": "&"
   },
   "KEY_7": {
     "alt": "{",
     "label": "7",
-    "shifted": "&"
+    "shifted": "/"
   },
   "KEY_8": {
     "alt": "[",
     "label": "8",
-    "shifted": "*"
+    "shifted": "("
   },
   "KEY_9": {
     "alt": "]",
     "label": "9",
-    "shifted": "("
+    "shifted": ")"
   },
   "KEY_A": {
     "alt": "æ",
     "label": "a"
   },
   "KEY_APOSTROPHE": {
-    "alt": "ˆ",
-    "label": "'",
-    "shifted": "@"
+    "alt": "{",
+    "label": "´",
+    "shifted": "¨"
   },
   "KEY_B": {
     "alt": "“",
     "label": "b"
   },
   "KEY_BACKSLASH": {
-    "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "alt": "}",
+    "label": "ç"
   },
   "KEY_C": {
     "alt": "¢",
@@ -74,7 +73,7 @@
   "KEY_COMMA": {
     "alt": "•",
     "label": ",",
-    "shifted": "<"
+    "shifted": ";"
   },
   "KEY_D": {
     "alt": "ð",
@@ -83,15 +82,16 @@
   "KEY_DOT": {
     "alt": "·",
     "label": ".",
-    "shifted": ">"
+    "shifted": ":"
   },
   "KEY_E": {
+    "alt": "€",
     "label": "e"
   },
   "KEY_EQUAL": {
     "alt": "¸",
-    "label": "=",
-    "shifted": "+"
+    "label": "¡",
+    "shifted": "¿"
   },
   "KEY_F": {
     "alt": "đ",
@@ -100,11 +100,6 @@
   "KEY_G": {
     "alt": "ŋ",
     "label": "g"
-  },
-  "KEY_GRAVE": {
-    "alt": "|",
-    "label": "`",
-    "shifted": "¬"
   },
   "KEY_H": {
     "alt": "ħ",
@@ -127,9 +122,9 @@
     "label": "l"
   },
   "KEY_LEFTBRACE": {
-    "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "alt": "[",
+    "label": "`",
+    "shifted": "ˆ"
   },
   "KEY_M": {
     "alt": "µ",
@@ -137,8 +132,8 @@
   },
   "KEY_MINUS": {
     "alt": "\\",
-    "label": "-",
-    "shifted": "_"
+    "label": "'",
+    "shifted": "?"
   },
   "KEY_N": {
     "alt": "”",
@@ -161,23 +156,22 @@
     "label": "r"
   },
   "KEY_RIGHTBRACE": {
-    "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "alt": "]",
+    "label": "+",
+    "shifted": "*"
   },
   "KEY_S": {
     "alt": "ß",
     "label": "s"
   },
   "KEY_SEMICOLON": {
-    "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "alt": "˜",
+    "label": "ñ"
   },
   "KEY_SLASH": {
     "alt": "◌̣",
-    "label": "/",
-    "shifted": "?"
+    "label": "-",
+    "shifted": "_"
   },
   "KEY_T": {
     "alt": "ŧ",

--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -1,62 +1,62 @@
 {
   "KEY_0": {
-    "alt": "}",
-    "label": "0",
-    "shifted": ")"
+    "alt": "@",
+    "label": "à",
+    "shifted": "0"
   },
   "KEY_1": {
     "alt": "¹",
-    "label": "1",
-    "shifted": "!"
+    "label": "&",
+    "shifted": "1"
   },
   "KEY_2": {
-    "alt": "²",
-    "label": "2",
-    "shifted": "\""
+    "alt": "~",
+    "label": "é",
+    "shifted": "2"
   },
   "KEY_3": {
-    "alt": "³",
-    "label": "3",
-    "shifted": "£"
+    "alt": "#",
+    "label": "\"",
+    "shifted": "3"
   },
   "KEY_4": {
-    "alt": "€",
-    "label": "4",
-    "shifted": "$"
+    "alt": "{",
+    "label": "'",
+    "shifted": "4"
   },
   "KEY_5": {
-    "alt": "½",
-    "label": "5",
-    "shifted": "%"
+    "alt": "[",
+    "label": "(",
+    "shifted": "5"
   },
   "KEY_6": {
-    "alt": "¾",
-    "label": "6",
-    "shifted": "^"
+    "alt": "|",
+    "label": "-",
+    "shifted": "6"
   },
   "KEY_7": {
-    "alt": "{",
-    "label": "7",
-    "shifted": "&"
+    "alt": "`",
+    "label": "è",
+    "shifted": "7"
   },
   "KEY_8": {
-    "alt": "[",
-    "label": "8",
-    "shifted": "*"
+    "alt": "\\",
+    "label": "_",
+    "shifted": "8"
   },
   "KEY_9": {
-    "alt": "]",
-    "label": "9",
-    "shifted": "("
+    "alt": "^",
+    "label": "ç",
+    "shifted": "9"
   },
   "KEY_A": {
-    "alt": "æ",
-    "label": "a"
+    "alt": "@",
+    "label": "q"
   },
   "KEY_APOSTROPHE": {
     "alt": "ˆ",
-    "label": "'",
-    "shifted": "@"
+    "label": "ù",
+    "shifted": "%"
   },
   "KEY_B": {
     "alt": "“",
@@ -64,8 +64,8 @@
   },
   "KEY_BACKSLASH": {
     "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "label": "*",
+    "shifted": "µ"
   },
   "KEY_C": {
     "alt": "¢",
@@ -73,8 +73,8 @@
   },
   "KEY_COMMA": {
     "alt": "•",
-    "label": ",",
-    "shifted": "<"
+    "label": ";",
+    "shifted": "."
   },
   "KEY_D": {
     "alt": "ð",
@@ -82,14 +82,15 @@
   },
   "KEY_DOT": {
     "alt": "·",
-    "label": ".",
-    "shifted": ">"
+    "label": ":",
+    "shifted": "/"
   },
   "KEY_E": {
+    "alt": "€",
     "label": "e"
   },
   "KEY_EQUAL": {
-    "alt": "¸",
+    "alt": "}",
     "label": "=",
     "shifted": "+"
   },
@@ -102,9 +103,9 @@
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
-    "label": "`",
-    "shifted": "¬"
+    "alt": "¬",
+    "label": "²",
+    "shifted": "~"
   },
   "KEY_H": {
     "alt": "ħ",
@@ -127,18 +128,18 @@
     "label": "l"
   },
   "KEY_LEFTBRACE": {
-    "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "label": "ˆ",
+    "shifted": "¨"
   },
   "KEY_M": {
-    "alt": "µ",
-    "label": "m"
+    "alt": "´",
+    "label": ",",
+    "shifted": "?"
   },
   "KEY_MINUS": {
-    "alt": "\\",
-    "label": "-",
-    "shifted": "_"
+    "alt": "]",
+    "label": ")",
+    "shifted": "°"
   },
   "KEY_N": {
     "alt": "”",
@@ -153,31 +154,30 @@
     "label": "p"
   },
   "KEY_Q": {
-    "alt": "@",
-    "label": "q"
+    "alt": "æ",
+    "label": "a"
   },
   "KEY_R": {
     "alt": "¶",
     "label": "r"
   },
   "KEY_RIGHTBRACE": {
-    "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "alt": "¤",
+    "label": "$",
+    "shifted": "£"
   },
   "KEY_S": {
     "alt": "ß",
     "label": "s"
   },
   "KEY_SEMICOLON": {
-    "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "alt": "µ",
+    "label": "m"
   },
   "KEY_SLASH": {
     "alt": "◌̣",
-    "label": "/",
-    "shifted": "?"
+    "label": "!",
+    "shifted": "§"
   },
   "KEY_T": {
     "alt": "ŧ",
@@ -192,8 +192,7 @@
     "label": "v"
   },
   "KEY_W": {
-    "alt": "ſ",
-    "label": "w"
+    "label": "z"
   },
   "KEY_X": {
     "label": "x"
@@ -203,6 +202,7 @@
     "label": "y"
   },
   "KEY_Z": {
-    "label": "z"
+    "alt": "ł",
+    "label": "w"
   }
 }

--- a/config/locales/gr.json
+++ b/config/locales/gr.json
@@ -1,208 +1,205 @@
 {
   "KEY_0": {
-    "alt": "}",
+    "alt": "°",
     "label": "0",
     "shifted": ")"
   },
   "KEY_1": {
-    "alt": "¹",
+    "alt": "•",
     "label": "1",
     "shifted": "!"
   },
   "KEY_2": {
-    "alt": "²",
+    "alt": "½",
     "label": "2",
-    "shifted": "\""
+    "shifted": "@"
   },
   "KEY_3": {
-    "alt": "³",
+    "alt": "£",
     "label": "3",
-    "shifted": "£"
+    "shifted": "#"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "¼",
     "label": "4",
     "shifted": "$"
   },
   "KEY_5": {
-    "alt": "½",
+    "alt": "€",
     "label": "5",
     "shifted": "%"
   },
   "KEY_6": {
-    "alt": "¾",
+    "alt": "ϰ",
     "label": "6",
     "shifted": "^"
   },
   "KEY_7": {
-    "alt": "{",
+    "alt": "ϗ",
     "label": "7",
     "shifted": "&"
   },
   "KEY_8": {
-    "alt": "[",
+    "alt": "₯",
     "label": "8",
     "shifted": "*"
   },
   "KEY_9": {
-    "alt": "]",
+    "alt": "¦",
     "label": "9",
     "shifted": "("
   },
   "KEY_A": {
-    "alt": "æ",
-    "label": "a"
+    "label": "α"
   },
   "KEY_APOSTROPHE": {
-    "alt": "ˆ",
+    "alt": "`",
     "label": "'",
-    "shifted": "@"
+    "shifted": "\""
   },
   "KEY_B": {
-    "alt": "“",
-    "label": "b"
+    "alt": "ϐ",
+    "label": "β"
   },
   "KEY_BACKSLASH": {
-    "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "alt": "¬",
+    "label": "\\",
+    "shifted": "|"
   },
   "KEY_C": {
-    "alt": "¢",
-    "label": "c"
+    "alt": "©",
+    "label": "ψ"
   },
   "KEY_COMMA": {
-    "alt": "•",
     "label": ",",
     "shifted": "<"
   },
   "KEY_D": {
-    "alt": "ð",
-    "label": "d"
+    "alt": "↓",
+    "label": "δ"
   },
   "KEY_DOT": {
-    "alt": "·",
     "label": ".",
     "shifted": ">"
   },
   "KEY_E": {
-    "label": "e"
+    "alt": "€",
+    "label": "ε"
   },
   "KEY_EQUAL": {
-    "alt": "¸",
     "label": "=",
     "shifted": "+"
   },
   "KEY_F": {
-    "alt": "đ",
-    "label": "f"
+    "alt": "ϕ",
+    "label": "φ"
   },
   "KEY_G": {
-    "alt": "ŋ",
-    "label": "g"
+    "alt": "ϝ",
+    "label": "γ"
   },
   "KEY_GRAVE": {
-    "alt": "|",
+    "alt": "―",
     "label": "`",
-    "shifted": "¬"
+    "shifted": "~"
   },
   "KEY_H": {
-    "alt": "ħ",
-    "label": "h"
+    "alt": "ϳ",
+    "label": "η"
   },
   "KEY_I": {
-    "alt": "→",
-    "label": "i"
+    "alt": "ͻ",
+    "label": "ι"
   },
   "KEY_J": {
-    "alt": "◌̉",
-    "label": "j"
+    "alt": "ͼ",
+    "label": "ξ"
   },
   "KEY_K": {
-    "alt": "ĸ",
-    "label": "k"
+    "alt": "ϟ",
+    "label": "κ"
   },
   "KEY_L": {
-    "alt": "ł",
-    "label": "l"
+    "alt": "ϲ",
+    "label": "λ"
   },
   "KEY_LEFTBRACE": {
-    "alt": "¨",
+    "alt": "˜",
     "label": "[",
     "shifted": "{"
   },
   "KEY_M": {
-    "alt": "µ",
-    "label": "m"
+    "alt": "ϻ",
+    "label": "μ"
   },
   "KEY_MINUS": {
-    "alt": "\\",
+    "alt": "±",
     "label": "-",
     "shifted": "_"
   },
   "KEY_N": {
-    "alt": "”",
-    "label": "n"
+    "alt": "ʹ",
+    "label": "ν"
   },
   "KEY_O": {
-    "alt": "ø",
-    "label": "o"
+    "alt": "ϙ",
+    "label": "ο"
   },
   "KEY_P": {
-    "alt": "þ",
-    "label": "p"
+    "alt": "ϡ",
+    "label": "π"
   },
   "KEY_Q": {
-    "alt": "@",
-    "label": "q"
+    "alt": "·",
+    "label": ";",
+    "shifted": ":"
   },
   "KEY_R": {
-    "alt": "¶",
-    "label": "r"
+    "alt": "®",
+    "label": "ρ"
   },
   "KEY_RIGHTBRACE": {
-    "alt": "˜",
+    "alt": "ͺ",
     "label": "]",
     "shifted": "}"
   },
   "KEY_S": {
-    "alt": "ß",
-    "label": "s"
+    "alt": "§",
+    "label": "σ"
   },
   "KEY_SEMICOLON": {
-    "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "label": "´",
+    "shifted": "¨"
   },
   "KEY_SLASH": {
-    "alt": "◌̣",
     "label": "/",
     "shifted": "?"
   },
   "KEY_T": {
-    "alt": "ŧ",
-    "label": "t"
+    "label": "τ"
   },
   "KEY_U": {
-    "alt": "↓",
-    "label": "u"
+    "alt": "ϑ",
+    "label": "θ"
   },
   "KEY_V": {
-    "alt": "„",
-    "label": "v"
+    "alt": "ϖ",
+    "label": "ω"
   },
   "KEY_W": {
-    "alt": "ſ",
-    "label": "w"
+    "alt": "ϛ",
+    "label": "ς"
   },
   "KEY_X": {
-    "label": "x"
+    "alt": "→",
+    "label": "χ"
   },
   "KEY_Y": {
-    "alt": "←",
-    "label": "y"
+    "alt": "ϒ",
+    "label": "υ"
   },
   "KEY_Z": {
-    "label": "z"
+    "alt": "ͽ",
+    "label": "ζ"
   }
 }

--- a/config/locales/il.json
+++ b/config/locales/il.json
@@ -1,0 +1,225 @@
+{
+  "KEY_0": {
+    "alt": "‏",
+    "label": "0",
+    "shifted": "("
+  },
+  "KEY_1": {
+    "label": "1",
+    "shifted": "!"
+  },
+  "KEY_2": {
+    "label": "2",
+    "shifted": "@"
+  },
+  "KEY_3": {
+    "alt": "€",
+    "label": "3",
+    "shifted": "#"
+  },
+  "KEY_4": {
+    "alt": "₪",
+    "label": "4",
+    "shifted": "$"
+  },
+  "KEY_5": {
+    "alt": "°",
+    "label": "5",
+    "shifted": "%"
+  },
+  "KEY_6": {
+    "alt": "֫",
+    "label": "6",
+    "shifted": "^"
+  },
+  "KEY_7": {
+    "alt": "ֽ",
+    "label": "7",
+    "shifted": "&"
+  },
+  "KEY_8": {
+    "alt": "×",
+    "label": "8",
+    "shifted": "*"
+  },
+  "KEY_9": {
+    "alt": "‎",
+    "label": "9",
+    "shifted": ")"
+  },
+  "KEY_A": {
+    "alt": "ְ",
+    "label": "ש",
+    "shifted": "A"
+  },
+  "KEY_APOSTROPHE": {
+    "alt": "״",
+    "label": ",",
+    "shifted": "\""
+  },
+  "KEY_B": {
+    "label": "נ",
+    "shifted": "B"
+  },
+  "KEY_BACKSLASH": {
+    "alt": "ֻ",
+    "label": "\\",
+    "shifted": "|"
+  },
+  "KEY_C": {
+    "alt": "ֱ",
+    "label": "ב",
+    "shifted": "C"
+  },
+  "KEY_COMMA": {
+    "alt": "’",
+    "label": "ת",
+    "shifted": ">"
+  },
+  "KEY_D": {
+    "label": "ג",
+    "shifted": "D"
+  },
+  "KEY_DOT": {
+    "alt": "‚",
+    "label": "ץ",
+    "shifted": "<"
+  },
+  "KEY_E": {
+    "alt": "ָ",
+    "label": "ק",
+    "shifted": "E"
+  },
+  "KEY_EQUAL": {
+    "alt": "–",
+    "label": "=",
+    "shifted": "+"
+  },
+  "KEY_F": {
+    "label": "כ",
+    "shifted": "F"
+  },
+  "KEY_G": {
+    "alt": "ױ",
+    "label": "ע",
+    "shifted": "G"
+  },
+  "KEY_GRAVE": {
+    "alt": "׳",
+    "label": ";",
+    "shifted": "~"
+  },
+  "KEY_H": {
+    "alt": "ײ",
+    "label": "י",
+    "shifted": "H"
+  },
+  "KEY_I": {
+    "label": "ן",
+    "shifted": "I"
+  },
+  "KEY_J": {
+    "alt": "ִ",
+    "label": "ח",
+    "shifted": "J"
+  },
+  "KEY_K": {
+    "label": "ל",
+    "shifted": "K"
+  },
+  "KEY_L": {
+    "alt": "”",
+    "label": "ך",
+    "shifted": "L"
+  },
+  "KEY_LEFTBRACE": {
+    "alt": "ֲ",
+    "label": "]",
+    "shifted": "}"
+  },
+  "KEY_M": {
+    "alt": "ֵ",
+    "label": "צ",
+    "shifted": "M"
+  },
+  "KEY_MINUS": {
+    "alt": "־",
+    "label": "-",
+    "shifted": "_"
+  },
+  "KEY_N": {
+    "label": "מ",
+    "shifted": "N"
+  },
+  "KEY_O": {
+    "label": "ם",
+    "shifted": "O"
+  },
+  "KEY_P": {
+    "alt": "ַ",
+    "label": "פ",
+    "shifted": "P"
+  },
+  "KEY_Q": {
+    "alt": "ׂ",
+    "label": "/",
+    "shifted": "Q"
+  },
+  "KEY_R": {
+    "alt": "ֳ",
+    "label": "ר",
+    "shifted": "R"
+  },
+  "KEY_RIGHTBRACE": {
+    "alt": "ֿ",
+    "label": "[",
+    "shifted": "{"
+  },
+  "KEY_S": {
+    "alt": "ּ",
+    "label": "ד",
+    "shifted": "S"
+  },
+  "KEY_SEMICOLON": {
+    "alt": "„",
+    "label": "ף",
+    "shifted": ":"
+  },
+  "KEY_SLASH": {
+    "alt": "÷",
+    "label": ".",
+    "shifted": "?"
+  },
+  "KEY_T": {
+    "label": "א",
+    "shifted": "T"
+  },
+  "KEY_U": {
+    "alt": "ֹ",
+    "label": "ו",
+    "shifted": "U"
+  },
+  "KEY_V": {
+    "label": "ה",
+    "shifted": "V"
+  },
+  "KEY_W": {
+    "alt": "ׁ",
+    "label": "'",
+    "shifted": "W"
+  },
+  "KEY_X": {
+    "alt": "ֶ",
+    "label": "ס",
+    "shifted": "X"
+  },
+  "KEY_Y": {
+    "alt": "װ",
+    "label": "ט",
+    "shifted": "Y"
+  },
+  "KEY_Z": {
+    "label": "ז",
+    "shifted": "Z"
+  }
+}

--- a/config/locales/in.json
+++ b/config/locales/in.json
@@ -1,0 +1,215 @@
+{
+  "KEY_0": {
+    "alt": "0",
+    "label": "०",
+    "shifted": ")"
+  },
+  "KEY_1": {
+    "alt": "1",
+    "label": "१",
+    "shifted": "ऍ"
+  },
+  "KEY_2": {
+    "alt": "2",
+    "label": "२",
+    "shifted": "ॅ"
+  },
+  "KEY_3": {
+    "alt": "3",
+    "label": "३",
+    "shifted": "#"
+  },
+  "KEY_4": {
+    "alt": "4",
+    "label": "४",
+    "shifted": "$"
+  },
+  "KEY_5": {
+    "alt": "5",
+    "label": "५",
+    "shifted": "%"
+  },
+  "KEY_6": {
+    "alt": "6",
+    "label": "६",
+    "shifted": "^"
+  },
+  "KEY_7": {
+    "alt": "7",
+    "label": "७",
+    "shifted": "&"
+  },
+  "KEY_8": {
+    "alt": "8",
+    "label": "८",
+    "shifted": "*"
+  },
+  "KEY_9": {
+    "alt": "9",
+    "label": "९",
+    "shifted": "("
+  },
+  "KEY_A": {
+    "label": "ो",
+    "shifted": "ओ"
+  },
+  "KEY_APOSTROPHE": {
+    "label": "ट",
+    "shifted": "ठ"
+  },
+  "KEY_B": {
+    "label": "व",
+    "shifted": "ऴ"
+  },
+  "KEY_BACKSLASH": {
+    "alt": "\\",
+    "label": "ॉ",
+    "shifted": "ऑ"
+  },
+  "KEY_C": {
+    "alt": "॔",
+    "label": "म",
+    "shifted": "ण"
+  },
+  "KEY_COMMA": {
+    "alt": "॰",
+    "label": ",",
+    "shifted": "ष"
+  },
+  "KEY_D": {
+    "label": "्",
+    "shifted": "अ"
+  },
+  "KEY_DOT": {
+    "alt": "॥",
+    "label": ".",
+    "shifted": "।"
+  },
+  "KEY_E": {
+    "label": "ा",
+    "shifted": "आ"
+  },
+  "KEY_EQUAL": {
+    "alt": "ॄ",
+    "label": "ृ",
+    "shifted": "ऋ"
+  },
+  "KEY_F": {
+    "alt": "ॢ",
+    "label": "ि",
+    "shifted": "इ"
+  },
+  "KEY_G": {
+    "label": "ु",
+    "shifted": "उ"
+  },
+  "KEY_GRAVE": {
+    "alt": "`",
+    "label": "ॊ",
+    "shifted": "ऒ"
+  },
+  "KEY_H": {
+    "label": "प",
+    "shifted": "फ"
+  },
+  "KEY_I": {
+    "alt": "ग़",
+    "label": "ग",
+    "shifted": "घ"
+  },
+  "KEY_J": {
+    "label": "र",
+    "shifted": "ऱ"
+  },
+  "KEY_K": {
+    "alt": "क़",
+    "label": "क",
+    "shifted": "ख"
+  },
+  "KEY_L": {
+    "label": "त",
+    "shifted": "थ"
+  },
+  "KEY_LEFTBRACE": {
+    "alt": "ड़",
+    "label": "ड",
+    "shifted": "ढ"
+  },
+  "KEY_M": {
+    "label": "स",
+    "shifted": "श"
+  },
+  "KEY_MINUS": {
+    "label": "-",
+    "shifted": "ः"
+  },
+  "KEY_N": {
+    "label": "ल",
+    "shifted": "ळ"
+  },
+  "KEY_O": {
+    "label": "द",
+    "shifted": "ध"
+  },
+  "KEY_P": {
+    "alt": "ज़",
+    "label": "ज",
+    "shifted": "झ"
+  },
+  "KEY_Q": {
+    "label": "ौ",
+    "shifted": "औ"
+  },
+  "KEY_R": {
+    "alt": "ॣ",
+    "label": "ी",
+    "shifted": "ई"
+  },
+  "KEY_RIGHTBRACE": {
+    "label": "़",
+    "shifted": "ञ"
+  },
+  "KEY_S": {
+    "label": "े",
+    "shifted": "ए"
+  },
+  "KEY_SEMICOLON": {
+    "alt": "॒",
+    "label": "च",
+    "shifted": "छ"
+  },
+  "KEY_SLASH": {
+    "alt": "/",
+    "label": "य",
+    "shifted": "य़"
+  },
+  "KEY_T": {
+    "label": "ू",
+    "shifted": "ऊ"
+  },
+  "KEY_U": {
+    "label": "ह",
+    "shifted": "ङ"
+  },
+  "KEY_V": {
+    "label": "न",
+    "shifted": "ऩ"
+  },
+  "KEY_W": {
+    "label": "ै",
+    "shifted": "ऐ"
+  },
+  "KEY_X": {
+    "label": "ं",
+    "shifted": "ँ"
+  },
+  "KEY_Y": {
+    "label": "ब",
+    "shifted": "भ"
+  },
+  "KEY_Z": {
+    "alt": "॓",
+    "label": "ॆ",
+    "shifted": "ऎ"
+  }
+}

--- a/config/locales/index.json
+++ b/config/locales/index.json
@@ -1,0 +1,22 @@
+{
+  "ara": "Arabic",
+  "br": "Portuguese (Brazil)",
+  "de": "German",
+  "es": "Spanish",
+  "fr": "French",
+  "gb": "English (UK)",
+  "gr": "Greek",
+  "il": "Hebrew",
+  "in": "Hindi (Devanagari)",
+  "it": "Italian",
+  "latam": "Spanish (Latin America)",
+  "nl": "Dutch",
+  "pl": "Polish",
+  "pt": "Portuguese",
+  "ru": "Russian",
+  "th": "Thai",
+  "tr": "Turkish",
+  "ua": "Ukrainian",
+  "us": "English (US)",
+  "vn": "Vietnamese"
+}

--- a/config/locales/it.json
+++ b/config/locales/it.json
@@ -2,7 +2,7 @@
   "KEY_0": {
     "alt": "}",
     "label": "0",
-    "shifted": ")"
+    "shifted": "="
   },
   "KEY_1": {
     "alt": "¹",
@@ -20,7 +20,7 @@
     "shifted": "£"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "¼",
     "label": "4",
     "shifted": "$"
   },
@@ -30,51 +30,51 @@
     "shifted": "%"
   },
   "KEY_6": {
-    "alt": "¾",
+    "alt": "¬",
     "label": "6",
-    "shifted": "^"
+    "shifted": "&"
   },
   "KEY_7": {
     "alt": "{",
     "label": "7",
-    "shifted": "&"
+    "shifted": "/"
   },
   "KEY_8": {
     "alt": "[",
     "label": "8",
-    "shifted": "*"
+    "shifted": "("
   },
   "KEY_9": {
     "alt": "]",
     "label": "9",
-    "shifted": "("
+    "shifted": ")"
   },
   "KEY_A": {
     "alt": "æ",
     "label": "a"
   },
   "KEY_APOSTROPHE": {
-    "alt": "ˆ",
-    "label": "'",
-    "shifted": "@"
+    "alt": "#",
+    "label": "à",
+    "shifted": "°"
   },
   "KEY_B": {
-    "alt": "“",
+    "alt": "”",
     "label": "b"
   },
   "KEY_BACKSLASH": {
     "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "label": "ù",
+    "shifted": "§"
   },
   "KEY_C": {
     "alt": "¢",
     "label": "c"
   },
   "KEY_COMMA": {
-    "alt": "•",
+    "alt": "´",
     "label": ",",
-    "shifted": "<"
+    "shifted": ";"
   },
   "KEY_D": {
     "alt": "ð",
@@ -83,15 +83,16 @@
   "KEY_DOT": {
     "alt": "·",
     "label": ".",
-    "shifted": ">"
+    "shifted": ":"
   },
   "KEY_E": {
+    "alt": "€",
     "label": "e"
   },
   "KEY_EQUAL": {
-    "alt": "¸",
-    "label": "=",
-    "shifted": "+"
+    "alt": "~",
+    "label": "ì",
+    "shifted": "^"
   },
   "KEY_F": {
     "alt": "đ",
@@ -102,9 +103,9 @@
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
-    "label": "`",
-    "shifted": "¬"
+    "alt": "¬",
+    "label": "\\",
+    "shifted": "|"
   },
   "KEY_H": {
     "alt": "ħ",
@@ -127,21 +128,21 @@
     "label": "l"
   },
   "KEY_LEFTBRACE": {
-    "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "alt": "[",
+    "label": "è",
+    "shifted": "é"
   },
   "KEY_M": {
     "alt": "µ",
     "label": "m"
   },
   "KEY_MINUS": {
-    "alt": "\\",
-    "label": "-",
-    "shifted": "_"
+    "alt": "`",
+    "label": "'",
+    "shifted": "?"
   },
   "KEY_N": {
-    "alt": "”",
+    "alt": "ñ",
     "label": "n"
   },
   "KEY_O": {
@@ -161,23 +162,23 @@
     "label": "r"
   },
   "KEY_RIGHTBRACE": {
-    "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "alt": "]",
+    "label": "+",
+    "shifted": "*"
   },
   "KEY_S": {
     "alt": "ß",
     "label": "s"
   },
   "KEY_SEMICOLON": {
-    "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "alt": "@",
+    "label": "ò",
+    "shifted": "ç"
   },
   "KEY_SLASH": {
-    "alt": "◌̣",
-    "label": "/",
-    "shifted": "?"
+    "alt": "¯",
+    "label": "-",
+    "shifted": "_"
   },
   "KEY_T": {
     "alt": "ŧ",
@@ -188,7 +189,7 @@
     "label": "u"
   },
   "KEY_V": {
-    "alt": "„",
+    "alt": "“",
     "label": "v"
   },
   "KEY_W": {

--- a/config/locales/latam.json
+++ b/config/locales/latam.json
@@ -2,25 +2,25 @@
   "KEY_0": {
     "alt": "}",
     "label": "0",
-    "shifted": ")"
+    "shifted": "="
   },
   "KEY_1": {
-    "alt": "¹",
+    "alt": "|",
     "label": "1",
     "shifted": "!"
   },
   "KEY_2": {
-    "alt": "²",
+    "alt": "@",
     "label": "2",
     "shifted": "\""
   },
   "KEY_3": {
-    "alt": "³",
+    "alt": "·",
     "label": "3",
-    "shifted": "£"
+    "shifted": "#"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "~",
     "label": "4",
     "shifted": "$"
   },
@@ -30,24 +30,24 @@
     "shifted": "%"
   },
   "KEY_6": {
-    "alt": "¾",
+    "alt": "¬",
     "label": "6",
-    "shifted": "^"
+    "shifted": "&"
   },
   "KEY_7": {
     "alt": "{",
     "label": "7",
-    "shifted": "&"
+    "shifted": "/"
   },
   "KEY_8": {
     "alt": "[",
     "label": "8",
-    "shifted": "*"
+    "shifted": "("
   },
   "KEY_9": {
     "alt": "]",
     "label": "9",
-    "shifted": "("
+    "shifted": ")"
   },
   "KEY_A": {
     "alt": "æ",
@@ -55,8 +55,8 @@
   },
   "KEY_APOSTROPHE": {
     "alt": "ˆ",
-    "label": "'",
-    "shifted": "@"
+    "label": "{",
+    "shifted": "["
   },
   "KEY_B": {
     "alt": "“",
@@ -64,8 +64,8 @@
   },
   "KEY_BACKSLASH": {
     "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "label": "}",
+    "shifted": "]"
   },
   "KEY_C": {
     "alt": "¢",
@@ -74,7 +74,7 @@
   "KEY_COMMA": {
     "alt": "•",
     "label": ",",
-    "shifted": "<"
+    "shifted": ";"
   },
   "KEY_D": {
     "alt": "ð",
@@ -83,15 +83,16 @@
   "KEY_DOT": {
     "alt": "·",
     "label": ".",
-    "shifted": ">"
+    "shifted": ":"
   },
   "KEY_E": {
+    "alt": "€",
     "label": "e"
   },
   "KEY_EQUAL": {
     "alt": "¸",
-    "label": "=",
-    "shifted": "+"
+    "label": "¿",
+    "shifted": "¡"
   },
   "KEY_F": {
     "alt": "đ",
@@ -102,9 +103,9 @@
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
-    "label": "`",
-    "shifted": "¬"
+    "alt": "¬",
+    "label": "|",
+    "shifted": "°"
   },
   "KEY_H": {
     "alt": "ħ",
@@ -127,9 +128,8 @@
     "label": "l"
   },
   "KEY_LEFTBRACE": {
-    "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "label": "´",
+    "shifted": "¨"
   },
   "KEY_M": {
     "alt": "µ",
@@ -137,8 +137,8 @@
   },
   "KEY_MINUS": {
     "alt": "\\",
-    "label": "-",
-    "shifted": "_"
+    "label": "'",
+    "shifted": "?"
   },
   "KEY_N": {
     "alt": "”",
@@ -161,23 +161,22 @@
     "label": "r"
   },
   "KEY_RIGHTBRACE": {
-    "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "alt": "~",
+    "label": "+",
+    "shifted": "*"
   },
   "KEY_S": {
     "alt": "ß",
     "label": "s"
   },
   "KEY_SEMICOLON": {
-    "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "alt": "~",
+    "label": "ñ"
   },
   "KEY_SLASH": {
     "alt": "◌̣",
-    "label": "/",
-    "shifted": "?"
+    "label": "-",
+    "shifted": "_"
   },
   "KEY_T": {
     "alt": "ŧ",

--- a/config/locales/nl.json
+++ b/config/locales/nl.json
@@ -1,8 +1,8 @@
 {
   "KEY_0": {
-    "alt": "}",
+    "alt": "°",
     "label": "0",
-    "shifted": ")"
+    "shifted": "'"
   },
   "KEY_1": {
     "alt": "¹",
@@ -17,10 +17,10 @@
   "KEY_3": {
     "alt": "³",
     "label": "3",
-    "shifted": "£"
+    "shifted": "#"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "¼",
     "label": "4",
     "shifted": "$"
   },
@@ -32,49 +32,49 @@
   "KEY_6": {
     "alt": "¾",
     "label": "6",
-    "shifted": "^"
-  },
-  "KEY_7": {
-    "alt": "{",
-    "label": "7",
     "shifted": "&"
   },
-  "KEY_8": {
-    "alt": "[",
-    "label": "8",
-    "shifted": "*"
+  "KEY_7": {
+    "alt": "£",
+    "label": "7",
+    "shifted": "_"
   },
-  "KEY_9": {
-    "alt": "]",
-    "label": "9",
+  "KEY_8": {
+    "alt": "{",
+    "label": "8",
     "shifted": "("
   },
+  "KEY_9": {
+    "alt": "}",
+    "label": "9",
+    "shifted": ")"
+  },
   "KEY_A": {
-    "alt": "æ",
+    "alt": "á",
     "label": "a"
   },
   "KEY_APOSTROPHE": {
-    "alt": "ˆ",
-    "label": "'",
-    "shifted": "@"
+    "alt": "'",
+    "label": "´",
+    "shifted": "`"
   },
   "KEY_B": {
-    "alt": "“",
+    "alt": "”",
     "label": "b"
   },
   "KEY_BACKSLASH": {
     "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "label": "<",
+    "shifted": ">"
   },
   "KEY_C": {
     "alt": "¢",
     "label": "c"
   },
   "KEY_COMMA": {
-    "alt": "•",
+    "alt": "¸",
     "label": ",",
-    "shifted": "<"
+    "shifted": ";"
   },
   "KEY_D": {
     "alt": "ð",
@@ -83,18 +83,19 @@
   "KEY_DOT": {
     "alt": "·",
     "label": ".",
-    "shifted": ">"
+    "shifted": ":"
   },
   "KEY_E": {
+    "alt": "€",
     "label": "e"
   },
   "KEY_EQUAL": {
     "alt": "¸",
-    "label": "=",
-    "shifted": "+"
+    "label": "°",
+    "shifted": "˜"
   },
   "KEY_F": {
-    "alt": "đ",
+    "alt": "ª",
     "label": "f"
   },
   "KEY_G": {
@@ -102,16 +103,16 @@
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
-    "label": "`",
-    "shifted": "¬"
+    "alt": "¬",
+    "label": "@",
+    "shifted": "§"
   },
   "KEY_H": {
     "alt": "ħ",
     "label": "h"
   },
   "KEY_I": {
-    "alt": "→",
+    "alt": "ï",
     "label": "i"
   },
   "KEY_J": {
@@ -127,29 +128,29 @@
     "label": "l"
   },
   "KEY_LEFTBRACE": {
-    "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "alt": "~",
+    "label": "¨",
+    "shifted": "ˆ"
   },
   "KEY_M": {
-    "alt": "µ",
+    "alt": "μ",
     "label": "m"
   },
   "KEY_MINUS": {
     "alt": "\\",
-    "label": "-",
-    "shifted": "_"
+    "label": "/",
+    "shifted": "?"
   },
   "KEY_N": {
-    "alt": "”",
+    "alt": "ñ",
     "label": "n"
   },
   "KEY_O": {
-    "alt": "ø",
+    "alt": "ò",
     "label": "o"
   },
   "KEY_P": {
-    "alt": "þ",
+    "alt": "¶",
     "label": "p"
   },
   "KEY_Q": {
@@ -162,8 +163,8 @@
   },
   "KEY_RIGHTBRACE": {
     "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "label": "*",
+    "shifted": "|"
   },
   "KEY_S": {
     "alt": "ß",
@@ -171,24 +172,24 @@
   },
   "KEY_SEMICOLON": {
     "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "label": "+",
+    "shifted": "±"
   },
   "KEY_SLASH": {
-    "alt": "◌̣",
-    "label": "/",
-    "shifted": "?"
+    "alt": "­",
+    "label": "-",
+    "shifted": "="
   },
   "KEY_T": {
-    "alt": "ŧ",
+    "alt": "þ",
     "label": "t"
   },
   "KEY_U": {
-    "alt": "↓",
+    "alt": "ü",
     "label": "u"
   },
   "KEY_V": {
-    "alt": "„",
+    "alt": "“",
     "label": "v"
   },
   "KEY_W": {
@@ -199,7 +200,7 @@
     "label": "x"
   },
   "KEY_Y": {
-    "alt": "←",
+    "alt": "ÿ",
     "label": "y"
   },
   "KEY_Z": {

--- a/config/locales/pl.json
+++ b/config/locales/pl.json
@@ -1,78 +1,76 @@
 {
   "KEY_0": {
-    "alt": "}",
     "label": "0",
     "shifted": ")"
   },
   "KEY_1": {
-    "alt": "¹",
+    "alt": "≠",
     "label": "1",
     "shifted": "!"
   },
   "KEY_2": {
     "alt": "²",
     "label": "2",
-    "shifted": "\""
+    "shifted": "@"
   },
   "KEY_3": {
     "alt": "³",
     "label": "3",
-    "shifted": "£"
+    "shifted": "#"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "¢",
     "label": "4",
     "shifted": "$"
   },
   "KEY_5": {
-    "alt": "½",
+    "alt": "€",
     "label": "5",
     "shifted": "%"
   },
   "KEY_6": {
-    "alt": "¾",
+    "alt": "½",
     "label": "6",
     "shifted": "^"
   },
   "KEY_7": {
-    "alt": "{",
+    "alt": "§",
     "label": "7",
     "shifted": "&"
   },
   "KEY_8": {
-    "alt": "[",
+    "alt": "·",
     "label": "8",
     "shifted": "*"
   },
   "KEY_9": {
-    "alt": "]",
     "label": "9",
     "shifted": "("
   },
   "KEY_A": {
-    "alt": "æ",
+    "alt": "ą",
     "label": "a"
   },
   "KEY_APOSTROPHE": {
     "alt": "ˆ",
     "label": "'",
-    "shifted": "@"
+    "shifted": "\""
   },
   "KEY_B": {
-    "alt": "“",
+    "alt": "”",
     "label": "b"
   },
   "KEY_BACKSLASH": {
     "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "label": "\\",
+    "shifted": "|"
   },
   "KEY_C": {
-    "alt": "¢",
+    "alt": "ć",
     "label": "c"
   },
   "KEY_COMMA": {
-    "alt": "•",
+    "alt": "≤",
     "label": ",",
     "shifted": "<"
   },
@@ -81,11 +79,12 @@
     "label": "d"
   },
   "KEY_DOT": {
-    "alt": "·",
+    "alt": "≥",
     "label": ".",
     "shifted": ">"
   },
   "KEY_E": {
+    "alt": "ę",
     "label": "e"
   },
   "KEY_EQUAL": {
@@ -94,7 +93,7 @@
     "shifted": "+"
   },
   "KEY_F": {
-    "alt": "đ",
+    "alt": "æ",
     "label": "f"
   },
   "KEY_G": {
@@ -102,12 +101,12 @@
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
+    "alt": "¬",
     "label": "`",
-    "shifted": "¬"
+    "shifted": "~"
   },
   "KEY_H": {
-    "alt": "ħ",
+    "alt": "’",
     "label": "h"
   },
   "KEY_I": {
@@ -115,11 +114,11 @@
     "label": "i"
   },
   "KEY_J": {
-    "alt": "◌̉",
+    "alt": "ə",
     "label": "j"
   },
   "KEY_K": {
-    "alt": "ĸ",
+    "alt": "…",
     "label": "k"
   },
   "KEY_L": {
@@ -136,16 +135,16 @@
     "label": "m"
   },
   "KEY_MINUS": {
-    "alt": "\\",
+    "alt": "–",
     "label": "-",
     "shifted": "_"
   },
   "KEY_N": {
-    "alt": "”",
+    "alt": "ń",
     "label": "n"
   },
   "KEY_O": {
-    "alt": "ø",
+    "alt": "ó",
     "label": "o"
   },
   "KEY_P": {
@@ -153,11 +152,11 @@
     "label": "p"
   },
   "KEY_Q": {
-    "alt": "@",
+    "alt": "π",
     "label": "q"
   },
   "KEY_R": {
-    "alt": "¶",
+    "alt": "©",
     "label": "r"
   },
   "KEY_RIGHTBRACE": {
@@ -166,7 +165,7 @@
     "shifted": "}"
   },
   "KEY_S": {
-    "alt": "ß",
+    "alt": "ś",
     "label": "s"
   },
   "KEY_SEMICOLON": {
@@ -180,7 +179,7 @@
     "shifted": "?"
   },
   "KEY_T": {
-    "alt": "ŧ",
+    "alt": "ß",
     "label": "t"
   },
   "KEY_U": {
@@ -192,10 +191,11 @@
     "label": "v"
   },
   "KEY_W": {
-    "alt": "ſ",
+    "alt": "œ",
     "label": "w"
   },
   "KEY_X": {
+    "alt": "ź",
     "label": "x"
   },
   "KEY_Y": {
@@ -203,6 +203,7 @@
     "label": "y"
   },
   "KEY_Z": {
+    "alt": "ż",
     "label": "z"
   }
 }

--- a/config/locales/pt.json
+++ b/config/locales/pt.json
@@ -2,7 +2,7 @@
   "KEY_0": {
     "alt": "}",
     "label": "0",
-    "shifted": ")"
+    "shifted": "="
   },
   "KEY_1": {
     "alt": "¹",
@@ -10,17 +10,17 @@
     "shifted": "!"
   },
   "KEY_2": {
-    "alt": "²",
+    "alt": "@",
     "label": "2",
     "shifted": "\""
   },
   "KEY_3": {
-    "alt": "³",
+    "alt": "£",
     "label": "3",
-    "shifted": "£"
+    "shifted": "#"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "§",
     "label": "4",
     "shifted": "$"
   },
@@ -30,33 +30,28 @@
     "shifted": "%"
   },
   "KEY_6": {
-    "alt": "¾",
+    "alt": "¬",
     "label": "6",
-    "shifted": "^"
+    "shifted": "&"
   },
   "KEY_7": {
     "alt": "{",
     "label": "7",
-    "shifted": "&"
+    "shifted": "/"
   },
   "KEY_8": {
     "alt": "[",
     "label": "8",
-    "shifted": "*"
+    "shifted": "("
   },
   "KEY_9": {
     "alt": "]",
     "label": "9",
-    "shifted": "("
+    "shifted": ")"
   },
   "KEY_A": {
     "alt": "æ",
     "label": "a"
-  },
-  "KEY_APOSTROPHE": {
-    "alt": "ˆ",
-    "label": "'",
-    "shifted": "@"
   },
   "KEY_B": {
     "alt": "“",
@@ -64,8 +59,8 @@
   },
   "KEY_BACKSLASH": {
     "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "label": "˜",
+    "shifted": "ˆ"
   },
   "KEY_C": {
     "alt": "¢",
@@ -74,7 +69,7 @@
   "KEY_COMMA": {
     "alt": "•",
     "label": ",",
-    "shifted": "<"
+    "shifted": ";"
   },
   "KEY_D": {
     "alt": "ð",
@@ -83,15 +78,11 @@
   "KEY_DOT": {
     "alt": "·",
     "label": ".",
-    "shifted": ">"
+    "shifted": ":"
   },
   "KEY_E": {
+    "alt": "€",
     "label": "e"
-  },
-  "KEY_EQUAL": {
-    "alt": "¸",
-    "label": "=",
-    "shifted": "+"
   },
   "KEY_F": {
     "alt": "đ",
@@ -102,9 +93,9 @@
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
-    "label": "`",
-    "shifted": "¬"
+    "alt": "¬",
+    "label": "\\",
+    "shifted": "|"
   },
   "KEY_H": {
     "alt": "ħ",
@@ -128,8 +119,8 @@
   },
   "KEY_LEFTBRACE": {
     "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "label": "+",
+    "shifted": "*"
   },
   "KEY_M": {
     "alt": "µ",
@@ -137,8 +128,8 @@
   },
   "KEY_MINUS": {
     "alt": "\\",
-    "label": "-",
-    "shifted": "_"
+    "label": "'",
+    "shifted": "?"
   },
   "KEY_N": {
     "alt": "”",
@@ -162,8 +153,8 @@
   },
   "KEY_RIGHTBRACE": {
     "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "label": "´",
+    "shifted": "`"
   },
   "KEY_S": {
     "alt": "ß",
@@ -171,13 +162,12 @@
   },
   "KEY_SEMICOLON": {
     "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "label": "ç"
   },
   "KEY_SLASH": {
     "alt": "◌̣",
-    "label": "/",
-    "shifted": "?"
+    "label": "-",
+    "shifted": "_"
   },
   "KEY_T": {
     "alt": "ŧ",

--- a/config/locales/ru.json
+++ b/config/locales/ru.json
@@ -9,15 +9,15 @@
   },
   "KEY_2": {
     "label": "2",
-    "shifted": "@"
+    "shifted": "\""
   },
   "KEY_3": {
     "label": "3",
-    "shifted": "#"
+    "shifted": "№"
   },
   "KEY_4": {
     "label": "4",
-    "shifted": "$"
+    "shifted": ";"
   },
   "KEY_5": {
     "label": "5",
@@ -25,13 +25,14 @@
   },
   "KEY_6": {
     "label": "6",
-    "shifted": "^"
+    "shifted": ":"
   },
   "KEY_7": {
     "label": "7",
-    "shifted": "&"
+    "shifted": "?"
   },
   "KEY_8": {
+    "alt": "₽",
     "label": "8",
     "shifted": "*"
   },
@@ -40,125 +41,118 @@
     "shifted": "("
   },
   "KEY_A": {
-    "label": "a"
+    "label": "ф"
   },
   "KEY_APOSTROPHE": {
-    "label": "'",
-    "shifted": "\""
+    "label": "э"
   },
   "KEY_B": {
-    "label": "b"
+    "label": "и"
   },
   "KEY_BACKSLASH": {
     "label": "\\",
-    "shifted": "|"
+    "shifted": "/"
   },
   "KEY_C": {
-    "label": "c"
+    "label": "с"
   },
   "KEY_COMMA": {
-    "label": ",",
-    "shifted": "<"
+    "label": "б"
   },
   "KEY_D": {
-    "label": "d"
+    "label": "в"
   },
   "KEY_DOT": {
-    "label": ".",
-    "shifted": ">"
+    "label": "ю"
   },
   "KEY_E": {
-    "label": "e"
+    "label": "у"
   },
   "KEY_EQUAL": {
     "label": "=",
     "shifted": "+"
   },
   "KEY_F": {
-    "label": "f"
+    "label": "а"
   },
   "KEY_G": {
-    "label": "g"
+    "label": "п"
   },
   "KEY_GRAVE": {
-    "label": "`",
-    "shifted": "~"
+    "label": "ё"
   },
   "KEY_H": {
-    "label": "h"
+    "label": "р"
   },
   "KEY_I": {
-    "label": "i"
+    "label": "ш"
   },
   "KEY_J": {
-    "label": "j"
+    "label": "о"
   },
   "KEY_K": {
-    "label": "k"
+    "label": "л"
   },
   "KEY_L": {
-    "label": "l"
+    "label": "д"
   },
   "KEY_LEFTBRACE": {
-    "label": "[",
-    "shifted": "{"
+    "label": "х"
   },
   "KEY_M": {
-    "label": "m"
+    "label": "ь"
   },
   "KEY_MINUS": {
     "label": "-",
     "shifted": "_"
   },
   "KEY_N": {
-    "label": "n"
+    "label": "т"
   },
   "KEY_O": {
-    "label": "o"
+    "label": "щ"
   },
   "KEY_P": {
-    "label": "p"
+    "label": "з"
   },
   "KEY_Q": {
-    "label": "q"
+    "label": "й"
   },
   "KEY_R": {
-    "label": "r"
+    "label": "к"
   },
   "KEY_RIGHTBRACE": {
-    "label": "]",
-    "shifted": "}"
+    "label": "ъ"
   },
   "KEY_S": {
-    "label": "s"
+    "label": "ы"
   },
   "KEY_SEMICOLON": {
-    "label": ";",
-    "shifted": ":"
+    "label": "ж"
   },
   "KEY_SLASH": {
-    "label": "/",
-    "shifted": "?"
+    "label": ".",
+    "shifted": ","
   },
   "KEY_T": {
-    "label": "t"
+    "label": "е"
   },
   "KEY_U": {
-    "label": "u"
+    "label": "г"
   },
   "KEY_V": {
-    "label": "v"
+    "label": "м"
   },
   "KEY_W": {
-    "label": "w"
+    "label": "ц"
   },
   "KEY_X": {
-    "label": "x"
+    "label": "ч"
   },
   "KEY_Y": {
-    "label": "y"
+    "label": "н"
   },
   "KEY_Z": {
-    "label": "z"
+    "label": "я"
   }
 }

--- a/config/locales/th.json
+++ b/config/locales/th.json
@@ -1,0 +1,190 @@
+{
+  "KEY_0": {
+    "label": "จ",
+    "shifted": "๗"
+  },
+  "KEY_1": {
+    "label": "ๅ",
+    "shifted": "+"
+  },
+  "KEY_2": {
+    "label": "/",
+    "shifted": "๑"
+  },
+  "KEY_3": {
+    "label": "-",
+    "shifted": "๒"
+  },
+  "KEY_4": {
+    "label": "ภ",
+    "shifted": "๓"
+  },
+  "KEY_5": {
+    "label": "ถ",
+    "shifted": "๔"
+  },
+  "KEY_6": {
+    "label": "ุ",
+    "shifted": "ู"
+  },
+  "KEY_7": {
+    "label": "ึ",
+    "shifted": "฿"
+  },
+  "KEY_8": {
+    "label": "ค",
+    "shifted": "๕"
+  },
+  "KEY_9": {
+    "label": "ต",
+    "shifted": "๖"
+  },
+  "KEY_A": {
+    "label": "ฟ",
+    "shifted": "ฤ"
+  },
+  "KEY_APOSTROPHE": {
+    "label": "ง",
+    "shifted": "."
+  },
+  "KEY_B": {
+    "label": "ิ",
+    "shifted": "ฺ"
+  },
+  "KEY_BACKSLASH": {
+    "label": "ฃ",
+    "shifted": "ฅ"
+  },
+  "KEY_C": {
+    "label": "แ",
+    "shifted": "ฉ"
+  },
+  "KEY_COMMA": {
+    "label": "ม",
+    "shifted": "ฒ"
+  },
+  "KEY_D": {
+    "label": "ก",
+    "shifted": "ฏ"
+  },
+  "KEY_DOT": {
+    "label": "ใ",
+    "shifted": "ฬ"
+  },
+  "KEY_E": {
+    "label": "ำ",
+    "shifted": "ฎ"
+  },
+  "KEY_EQUAL": {
+    "label": "ช",
+    "shifted": "๙"
+  },
+  "KEY_F": {
+    "label": "ด",
+    "shifted": "โ"
+  },
+  "KEY_G": {
+    "label": "เ",
+    "shifted": "ฌ"
+  },
+  "KEY_GRAVE": {
+    "label": "_",
+    "shifted": "%"
+  },
+  "KEY_H": {
+    "label": "้",
+    "shifted": "็"
+  },
+  "KEY_I": {
+    "label": "ร",
+    "shifted": "ณ"
+  },
+  "KEY_J": {
+    "label": "่",
+    "shifted": "๋"
+  },
+  "KEY_K": {
+    "label": "า",
+    "shifted": "ษ"
+  },
+  "KEY_L": {
+    "label": "ส",
+    "shifted": "ศ"
+  },
+  "KEY_LEFTBRACE": {
+    "label": "บ",
+    "shifted": "ฐ"
+  },
+  "KEY_M": {
+    "label": "ท",
+    "shifted": "?"
+  },
+  "KEY_MINUS": {
+    "label": "ข",
+    "shifted": "๘"
+  },
+  "KEY_N": {
+    "label": "ื",
+    "shifted": "์"
+  },
+  "KEY_O": {
+    "label": "น",
+    "shifted": "ฯ"
+  },
+  "KEY_P": {
+    "label": "ย",
+    "shifted": "ญ"
+  },
+  "KEY_Q": {
+    "label": "ๆ",
+    "shifted": "๐"
+  },
+  "KEY_R": {
+    "label": "พ",
+    "shifted": "ฑ"
+  },
+  "KEY_RIGHTBRACE": {
+    "label": "ล",
+    "shifted": ","
+  },
+  "KEY_S": {
+    "label": "ห",
+    "shifted": "ฆ"
+  },
+  "KEY_SEMICOLON": {
+    "label": "ว",
+    "shifted": "ซ"
+  },
+  "KEY_SLASH": {
+    "label": "ฝ",
+    "shifted": "ฦ"
+  },
+  "KEY_T": {
+    "label": "ะ",
+    "shifted": "ธ"
+  },
+  "KEY_U": {
+    "label": "ี",
+    "shifted": "๊"
+  },
+  "KEY_V": {
+    "label": "อ",
+    "shifted": "ฮ"
+  },
+  "KEY_W": {
+    "label": "ไ",
+    "shifted": "\""
+  },
+  "KEY_X": {
+    "label": "ป",
+    "shifted": ")"
+  },
+  "KEY_Y": {
+    "label": "ั",
+    "shifted": "ํ"
+  },
+  "KEY_Z": {
+    "label": "ผ",
+    "shifted": "("
+  }
+}

--- a/config/locales/tr.json
+++ b/config/locales/tr.json
@@ -2,27 +2,27 @@
   "KEY_0": {
     "alt": "}",
     "label": "0",
-    "shifted": ")"
+    "shifted": "="
   },
   "KEY_1": {
-    "alt": "¹",
+    "alt": ">",
     "label": "1",
     "shifted": "!"
   },
   "KEY_2": {
-    "alt": "²",
+    "alt": "£",
     "label": "2",
-    "shifted": "\""
+    "shifted": "'"
   },
   "KEY_3": {
-    "alt": "³",
+    "alt": "#",
     "label": "3",
-    "shifted": "£"
+    "shifted": "^"
   },
   "KEY_4": {
-    "alt": "€",
+    "alt": "$",
     "label": "4",
-    "shifted": "$"
+    "shifted": "+"
   },
   "KEY_5": {
     "alt": "½",
@@ -32,31 +32,31 @@
   "KEY_6": {
     "alt": "¾",
     "label": "6",
-    "shifted": "^"
+    "shifted": "&"
   },
   "KEY_7": {
     "alt": "{",
     "label": "7",
-    "shifted": "&"
+    "shifted": "/"
   },
   "KEY_8": {
     "alt": "[",
     "label": "8",
-    "shifted": "*"
+    "shifted": "("
   },
   "KEY_9": {
     "alt": "]",
     "label": "9",
-    "shifted": "("
+    "shifted": ")"
   },
   "KEY_A": {
-    "alt": "æ",
+    "alt": "â",
     "label": "a"
   },
   "KEY_APOSTROPHE": {
-    "alt": "ˆ",
-    "label": "'",
-    "shifted": "@"
+    "alt": "'",
+    "label": "i",
+    "shifted": "İ"
   },
   "KEY_B": {
     "alt": "“",
@@ -64,72 +64,65 @@
   },
   "KEY_BACKSLASH": {
     "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "label": ",",
+    "shifted": ";"
   },
   "KEY_C": {
     "alt": "¢",
     "label": "c"
   },
   "KEY_COMMA": {
-    "alt": "•",
-    "label": ",",
-    "shifted": "<"
+    "alt": "×",
+    "label": "ö"
   },
   "KEY_D": {
-    "alt": "ð",
     "label": "d"
   },
   "KEY_DOT": {
     "alt": "·",
-    "label": ".",
-    "shifted": ">"
+    "label": "ç"
   },
   "KEY_E": {
+    "alt": "€",
     "label": "e"
   },
   "KEY_EQUAL": {
-    "alt": "¸",
-    "label": "=",
-    "shifted": "+"
+    "alt": "|",
+    "label": "-",
+    "shifted": "_"
   },
   "KEY_F": {
-    "alt": "đ",
+    "alt": "ª",
     "label": "f"
   },
   "KEY_G": {
-    "alt": "ŋ",
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
-    "label": "`",
-    "shifted": "¬"
+    "alt": "<",
+    "label": "\"",
+    "shifted": "é"
   },
   "KEY_H": {
-    "alt": "ħ",
     "label": "h"
   },
   "KEY_I": {
-    "alt": "→",
-    "label": "i"
+    "alt": "î",
+    "label": "ı"
   },
   "KEY_J": {
     "alt": "◌̉",
     "label": "j"
   },
   "KEY_K": {
-    "alt": "ĸ",
     "label": "k"
   },
   "KEY_L": {
-    "alt": "ł",
     "label": "l"
   },
   "KEY_LEFTBRACE": {
     "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "label": "ğ"
   },
   "KEY_M": {
     "alt": "µ",
@@ -137,19 +130,18 @@
   },
   "KEY_MINUS": {
     "alt": "\\",
-    "label": "-",
-    "shifted": "_"
+    "label": "*",
+    "shifted": "?"
   },
   "KEY_N": {
     "alt": "”",
     "label": "n"
   },
   "KEY_O": {
-    "alt": "ø",
+    "alt": "ô",
     "label": "o"
   },
   "KEY_P": {
-    "alt": "þ",
     "label": "p"
   },
   "KEY_Q": {
@@ -161,9 +153,8 @@
     "label": "r"
   },
   "KEY_RIGHTBRACE": {
-    "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "alt": "~",
+    "label": "ü"
   },
   "KEY_S": {
     "alt": "ß",
@@ -171,20 +162,19 @@
   },
   "KEY_SEMICOLON": {
     "alt": "´",
-    "label": ";",
-    "shifted": ":"
+    "label": "ş"
   },
   "KEY_SLASH": {
-    "alt": "◌̣",
-    "label": "/",
-    "shifted": "?"
+    "alt": "˙",
+    "label": ".",
+    "shifted": ":"
   },
   "KEY_T": {
-    "alt": "ŧ",
+    "alt": "₺",
     "label": "t"
   },
   "KEY_U": {
-    "alt": "↓",
+    "alt": "û",
     "label": "u"
   },
   "KEY_V": {
@@ -192,7 +182,6 @@
     "label": "v"
   },
   "KEY_W": {
-    "alt": "ſ",
     "label": "w"
   },
   "KEY_X": {

--- a/config/locales/ua.json
+++ b/config/locales/ua.json
@@ -1,164 +1,186 @@
 {
   "KEY_0": {
+    "alt": "]",
     "label": "0",
     "shifted": ")"
   },
   "KEY_1": {
+    "alt": "¹",
     "label": "1",
     "shifted": "!"
   },
   "KEY_2": {
+    "alt": "²",
     "label": "2",
-    "shifted": "@"
+    "shifted": "\""
   },
   "KEY_3": {
+    "alt": "§",
     "label": "3",
-    "shifted": "#"
+    "shifted": "№"
   },
   "KEY_4": {
+    "alt": "$",
     "label": "4",
-    "shifted": "$"
+    "shifted": ";"
   },
   "KEY_5": {
+    "alt": "°",
     "label": "5",
     "shifted": "%"
   },
   "KEY_6": {
+    "alt": "<",
     "label": "6",
-    "shifted": "^"
+    "shifted": ":"
   },
   "KEY_7": {
+    "alt": ">",
     "label": "7",
-    "shifted": "&"
+    "shifted": "?"
   },
   "KEY_8": {
     "label": "8",
     "shifted": "*"
   },
   "KEY_9": {
+    "alt": "[",
     "label": "9",
     "shifted": "("
   },
   "KEY_A": {
-    "label": "a"
+    "label": "ф"
   },
   "KEY_APOSTROPHE": {
-    "label": "'",
-    "shifted": "\""
+    "alt": "э",
+    "label": "є"
   },
   "KEY_B": {
-    "label": "b"
+    "label": "и"
   },
   "KEY_BACKSLASH": {
-    "label": "\\",
-    "shifted": "|"
+    "alt": "\\",
+    "label": "ґ"
   },
   "KEY_C": {
-    "label": "c"
+    "alt": "©",
+    "label": "с"
   },
   "KEY_COMMA": {
-    "label": ",",
-    "shifted": "<"
+    "label": "б"
   },
   "KEY_D": {
-    "label": "d"
+    "label": "в"
   },
   "KEY_DOT": {
-    "label": ".",
-    "shifted": ">"
+    "label": "ю"
   },
   "KEY_E": {
-    "label": "e"
+    "alt": "ў",
+    "label": "у"
   },
   "KEY_EQUAL": {
+    "alt": "≠",
     "label": "=",
     "shifted": "+"
   },
   "KEY_F": {
-    "label": "f"
+    "label": "а"
   },
   "KEY_G": {
-    "label": "g"
+    "label": "п"
   },
   "KEY_GRAVE": {
-    "label": "`",
-    "shifted": "~"
+    "alt": "◌́",
+    "label": "'",
+    "shifted": "ʼ"
   },
   "KEY_H": {
-    "label": "h"
+    "label": "р"
   },
   "KEY_I": {
-    "label": "i"
+    "label": "ш"
   },
   "KEY_J": {
-    "label": "j"
+    "label": "о"
   },
   "KEY_K": {
-    "label": "k"
+    "alt": "љ",
+    "label": "л"
   },
   "KEY_L": {
-    "label": "l"
+    "alt": "ђ",
+    "label": "д"
   },
   "KEY_LEFTBRACE": {
-    "label": "[",
-    "shifted": "{"
+    "label": "х"
   },
   "KEY_M": {
-    "label": "m"
+    "label": "ь"
   },
   "KEY_MINUS": {
+    "alt": "—",
     "label": "-",
     "shifted": "_"
   },
   "KEY_N": {
-    "label": "n"
+    "alt": "™",
+    "label": "т"
   },
   "KEY_O": {
-    "label": "o"
+    "label": "щ"
   },
   "KEY_P": {
-    "label": "p"
+    "label": "з"
   },
   "KEY_Q": {
-    "label": "q"
+    "alt": "ј",
+    "label": "й"
   },
   "KEY_R": {
-    "label": "r"
+    "alt": "®",
+    "label": "к"
   },
   "KEY_RIGHTBRACE": {
-    "label": "]",
-    "shifted": "}"
+    "alt": "ъ",
+    "label": "ї"
   },
   "KEY_S": {
-    "label": "s"
+    "alt": "ы",
+    "label": "і"
   },
   "KEY_SEMICOLON": {
-    "label": ";",
-    "shifted": ":"
+    "label": "ж"
   },
   "KEY_SLASH": {
-    "label": "/",
-    "shifted": "?"
+    "alt": "/",
+    "label": ".",
+    "shifted": ","
   },
   "KEY_T": {
-    "label": "t"
+    "alt": "ё",
+    "label": "е"
   },
   "KEY_U": {
-    "label": "u"
+    "alt": "ґ",
+    "label": "г"
   },
   "KEY_V": {
-    "label": "v"
+    "label": "м"
   },
   "KEY_W": {
-    "label": "w"
+    "alt": "џ",
+    "label": "ц"
   },
   "KEY_X": {
-    "label": "x"
+    "alt": "ћ",
+    "label": "ч"
   },
   "KEY_Y": {
-    "label": "y"
+    "alt": "њ",
+    "label": "н"
   },
   "KEY_Z": {
-    "label": "z"
+    "label": "я"
   }
 }

--- a/config/locales/vn.json
+++ b/config/locales/vn.json
@@ -1,87 +1,67 @@
 {
   "KEY_0": {
-    "alt": "}",
-    "label": "0",
-    "shifted": ")"
+    "label": "đ"
   },
   "KEY_1": {
-    "alt": "¹",
-    "label": "1",
-    "shifted": "!"
+    "label": "ă"
   },
   "KEY_2": {
-    "alt": "²",
-    "label": "2",
-    "shifted": "\""
+    "label": "â"
   },
   "KEY_3": {
-    "alt": "³",
-    "label": "3",
-    "shifted": "£"
+    "label": "ê"
   },
   "KEY_4": {
-    "alt": "€",
-    "label": "4",
-    "shifted": "$"
+    "label": "ô"
   },
   "KEY_5": {
-    "alt": "½",
-    "label": "5",
+    "alt": "`",
+    "label": "◌̀",
     "shifted": "%"
   },
   "KEY_6": {
-    "alt": "¾",
-    "label": "6",
+    "label": "◌̉",
     "shifted": "^"
   },
   "KEY_7": {
-    "alt": "{",
-    "label": "7",
+    "alt": "˜",
+    "label": "◌̃",
     "shifted": "&"
   },
   "KEY_8": {
-    "alt": "[",
-    "label": "8",
+    "alt": "´",
+    "label": "◌́",
     "shifted": "*"
   },
   "KEY_9": {
-    "alt": "]",
-    "label": "9",
+    "label": "◌̣",
     "shifted": "("
   },
   "KEY_A": {
-    "alt": "æ",
     "label": "a"
   },
   "KEY_APOSTROPHE": {
-    "alt": "ˆ",
     "label": "'",
-    "shifted": "@"
+    "shifted": "\""
   },
   "KEY_B": {
-    "alt": "“",
     "label": "b"
   },
   "KEY_BACKSLASH": {
-    "alt": "`",
-    "label": "#",
-    "shifted": "~"
+    "label": "\\",
+    "shifted": "|"
   },
   "KEY_C": {
-    "alt": "¢",
     "label": "c"
   },
   "KEY_COMMA": {
-    "alt": "•",
     "label": ",",
     "shifted": "<"
   },
   "KEY_D": {
-    "alt": "ð",
     "label": "d"
   },
   "KEY_DOT": {
-    "alt": "·",
     "label": ".",
     "shifted": ">"
   },
@@ -89,117 +69,89 @@
     "label": "e"
   },
   "KEY_EQUAL": {
-    "alt": "¸",
-    "label": "=",
+    "label": "₫",
     "shifted": "+"
   },
   "KEY_F": {
-    "alt": "đ",
     "label": "f"
   },
   "KEY_G": {
-    "alt": "ŋ",
     "label": "g"
   },
   "KEY_GRAVE": {
-    "alt": "|",
     "label": "`",
-    "shifted": "¬"
+    "shifted": "~"
   },
   "KEY_H": {
-    "alt": "ħ",
     "label": "h"
   },
   "KEY_I": {
-    "alt": "→",
     "label": "i"
   },
   "KEY_J": {
-    "alt": "◌̉",
     "label": "j"
   },
   "KEY_K": {
-    "alt": "ĸ",
     "label": "k"
   },
   "KEY_L": {
-    "alt": "ł",
     "label": "l"
   },
   "KEY_LEFTBRACE": {
-    "alt": "¨",
-    "label": "[",
-    "shifted": "{"
+    "label": "ư"
   },
   "KEY_M": {
-    "alt": "µ",
     "label": "m"
   },
   "KEY_MINUS": {
-    "alt": "\\",
     "label": "-",
     "shifted": "_"
   },
   "KEY_N": {
-    "alt": "”",
     "label": "n"
   },
   "KEY_O": {
-    "alt": "ø",
     "label": "o"
   },
   "KEY_P": {
-    "alt": "þ",
     "label": "p"
   },
   "KEY_Q": {
-    "alt": "@",
     "label": "q"
   },
   "KEY_R": {
-    "alt": "¶",
     "label": "r"
   },
   "KEY_RIGHTBRACE": {
-    "alt": "˜",
-    "label": "]",
-    "shifted": "}"
+    "label": "ơ"
   },
   "KEY_S": {
-    "alt": "ß",
     "label": "s"
   },
   "KEY_SEMICOLON": {
-    "alt": "´",
     "label": ";",
     "shifted": ":"
   },
   "KEY_SLASH": {
-    "alt": "◌̣",
     "label": "/",
     "shifted": "?"
   },
   "KEY_T": {
-    "alt": "ŧ",
     "label": "t"
   },
   "KEY_U": {
-    "alt": "↓",
     "label": "u"
   },
   "KEY_V": {
-    "alt": "„",
     "label": "v"
   },
   "KEY_W": {
-    "alt": "ſ",
     "label": "w"
   },
   "KEY_X": {
     "label": "x"
   },
   "KEY_Y": {
-    "alt": "←",
     "label": "y"
   },
   "KEY_Z": {

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,7 @@ install -m755 "$HERE/bin/handheld-kbd-dock-rect" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-install-filter" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-toggle" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-ctl" "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-locales" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-fix-pointer" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-build-dict" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-focus-probe" "$BIN/"
@@ -70,6 +71,10 @@ import json, os, shutil, sys
 
 SRC, DST = sys.argv[1], sys.argv[2]
 ACTION_KINDS = {"locale", "hide", "size", "opacity", "move"}
+# Ordinary keys a release added. Without AltGr most non-English layouts cannot type
+# their own characters at all, so an upgraded layout that lacks it is missing the
+# feature entirely rather than just a convenience.
+NEW_KEYS = {"KEY_RIGHTALT"}
 RETIRED = ("dock", "dock_edges")          # v1.0.3's docking slots, replaced by unlock/drag
 
 def load(p):
@@ -95,17 +100,21 @@ for name in sorted(os.listdir(os.path.join(SRC, "layouts"))):
         print(f"handheld-kbd: skipping {name} ({ex})", file=sys.stderr)
         continue
     have = {k.get("kind") for row in mine.get("rows", []) for k in row}
+    have_keys = {k.get("key") for row in mine.get("rows", []) for k in row}
     added = []
     for ri, row in enumerate(shipped.get("rows", [])):
         for ki, key in enumerate(row):
-            kind = key.get("kind")
-            if kind not in ACTION_KINDS or kind in have:
+            kind, kname = key.get("kind"), key.get("key")
+            action = kind in ACTION_KINDS and kind not in have
+            plain = kname in NEW_KEYS and kname not in have_keys
+            if not action and not plain:
                 continue
             # same row if the layout still has one, else the first row; same offset if it fits
             target = mine["rows"][ri] if ri < len(mine.get("rows", [])) else mine["rows"][0]
             target.insert(min(ki, len(target)), dict(key))
             have.add(kind)
-            added.append(key.get("label") or kind)
+            have_keys.add(kname)
+            added.append(key.get("label") or kind or kname)
     if added:
         shutil.copy(dp, dp + ".bak")
         save(dp, mine)
@@ -123,8 +132,13 @@ try:
 except Exception as ex:
     print(f"handheld-kbd: config tidy skipped ({ex})", file=sys.stderr)
 PY
+# Locale files are labels, not settings — they are generated from xkeyboard-config and
+# gain keys as layouts are added, so an old copy means a keyboard drawn with the wrong
+# captions. Refresh them, keeping a .bak of anything the user had actually changed.
 for f in "$HERE"/config/locales/*.json; do
-  d="$CFG/locales/$(basename "$f")"; [ -f "$d" ] || install -m644 "$f" "$d"
+  d="$CFG/locales/$(basename "$f")"
+  if [ -f "$d" ] && ! cmp -s "$f" "$d"; then cp "$d" "$d.bak"; fi
+  install -m644 "$f" "$d"
 done
 
 # --- on a fresh install, auto-pick the trigger mode for this device ---

--- a/tools/build-locales.py
+++ b/tools/build-locales.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Generate config/locales/*.json from xkeyboard-config.
+
+This keyboard injects real keycodes, so what a key TYPES is decided entirely by the OS
+XKB layout. A locale file therefore contains no behaviour at all — only the labels to
+paint on the keys so that what you see matches what you get.
+
+Typing those by hand for twenty layouts would be twenty chances to be subtly wrong, in
+scripts most of us can't proofread. So they are generated from the same data the OS
+itself uses: xkeyboard-config's symbol files for the key-to-keysym mapping, and
+xorgproto's keysymdef.h for the keysym-to-character mapping.
+
+    tools/build-locales.py --fetch          download the sources, then generate
+    tools/build-locales.py --src DIR        generate from an existing checkout
+                                            (or /usr/share/X11/xkb on a Linux box)
+
+Output is committed to the repo: an install needs no network and no xkb parsing.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT = os.path.join(os.path.dirname(HERE), "config", "locales")
+
+XKB_BASE = ("https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config"
+            "/-/raw/master/symbols/")
+KEYSYMDEF = ("https://gitlab.freedesktop.org/xorg/proto/xorgproto"
+             "/-/raw/master/include/X11/keysymdef.h")
+
+# The twenty layouts we ship labels for. Chosen for reach — the most widely spoken
+# languages an XKB layout can actually serve — plus the two that were asked for.
+#
+# Deliberately absent: Chinese, Japanese and Korean. Those are not keyboard layouts but
+# input methods; no mapping of keycodes to characters can produce them, and pretending
+# otherwise with a labelled keyboard would be a lie about what pressing the key does.
+LAYOUTS = [
+    ("us",    "English (US)"),
+    ("gb",    "English (UK)"),
+    ("de",    "German"),
+    ("fr",    "French"),
+    ("es",    "Spanish"),
+    ("latam", "Spanish (Latin America)"),
+    ("it",    "Italian"),
+    ("pt",    "Portuguese"),
+    ("br",    "Portuguese (Brazil)"),
+    ("nl",    "Dutch"),
+    ("pl",    "Polish"),
+    ("tr",    "Turkish"),
+    ("ru",    "Russian"),
+    ("ua",    "Ukrainian"),
+    ("gr",    "Greek"),
+    ("ara",   "Arabic"),
+    ("il",    "Hebrew"),
+    ("in",    "Hindi (Devanagari)"),
+    ("th",    "Thai"),
+    ("vn",    "Vietnamese"),
+]
+
+# XKB's key names for the keys this keyboard actually has. Anything else in a symbol
+# file (keypad, the extra key on a 102-key board) has nowhere to go.
+XKB_TO_EVDEV = {
+    "TLDE": "KEY_GRAVE",
+    **{f"AE{i:02d}": f"KEY_{d}" for i, d in enumerate("1234567890", start=1)},
+    "AE11": "KEY_MINUS", "AE12": "KEY_EQUAL",
+    **{f"AD{i:02d}": f"KEY_{c}" for i, c in enumerate("QWERTYUIOP", start=1)},
+    "AD11": "KEY_LEFTBRACE", "AD12": "KEY_RIGHTBRACE",
+    **{f"AC{i:02d}": f"KEY_{c}" for i, c in enumerate("ASDFGHJKL", start=1)},
+    "AC10": "KEY_SEMICOLON", "AC11": "KEY_APOSTROPHE",
+    "BKSL": "KEY_BACKSLASH",
+    **{f"AB{i:02d}": f"KEY_{c}" for i, c in enumerate("ZXCVBNM", start=1)},
+    "AB08": "KEY_COMMA", "AB09": "KEY_DOT", "AB10": "KEY_SLASH",
+}
+
+# Dead keys produce nothing on their own, so keysymdef has no character for them. Show
+# the spacing form of the accent they will add — that is what the key means to a user.
+DEAD_KEYS = {
+    "dead_grave": "`", "dead_acute": "´", "dead_circumflex": "ˆ", "dead_tilde": "˜",
+    "dead_macron": "¯", "dead_breve": "˘", "dead_abovedot": "˙", "dead_diaeresis": "¨",
+    "dead_abovering": "˚", "dead_doubleacute": "˝", "dead_caron": "ˇ",
+    "dead_cedilla": "¸", "dead_ogonek": "˛", "dead_iota": "ͺ", "dead_belowdot": "◌̣",
+    "dead_hook": "◌̉", "dead_horn": "◌̛", "dead_stroke": "◌̸", "dead_belowcomma": "◌̦",
+    "dead_greek": "μ", "dead_currency": "¤",
+}
+
+SKIP = {"NoSymbol", "VoidSymbol", "any"}
+
+_KEY_RE = re.compile(r"""^\s*key\s*<(\w+)>\s*\{(.*?)\}\s*;""", re.M | re.S)
+_GROUP_RE = re.compile(r"\[([^\]]*)\]")
+_TYPE_RE = re.compile(r'\b(?:type|symbols|actions|virtualMods)\s*(?:\[[^\]]*\])?\s*=\s*(?:"[^"]*"|\w+)')
+_INCLUDE_RE = re.compile(r'^\s*include\s+"([^"]+)"', re.M)
+_BLOCK_RE = re.compile(r'(default\s+)?[\w\s]*xkb_symbols\s+"([^"]+)"\s*\{')
+
+
+def fetch(url, path):
+    if os.path.exists(path):
+        return path
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    try:
+        with urllib.request.urlopen(url, timeout=30) as r, open(path, "wb") as f:
+            f.write(r.read())
+        return path
+    except Exception as ex:
+        # A Python without a usable CA bundle is common enough (macOS system python,
+        # among others) that failing here would just be annoying. curl has its own.
+        if subprocess.run(["curl", "-sSfL", "-o", path, url]).returncode == 0:
+            return path
+        if os.path.exists(path):
+            os.remove(path)
+        raise ex
+
+
+def load_keysyms(path):
+    """keysym name -> character, from keysymdef.h's U+XXXX comments."""
+    table = {}
+    pat = re.compile(r"^#define\s+XK_(\w+)\s+0x[0-9a-fA-F]+\s*/\*[<\s]*U\+([0-9A-Fa-f]{4,6})")
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            m = pat.match(line)
+            if m:
+                table[m.group(1)] = chr(int(m.group(2), 16))
+    table.update(DEAD_KEYS)
+    return table
+
+
+def keysym_char(sym, table):
+    """One keysym as the character it produces, or None if it isn't printable."""
+    sym = sym.strip()
+    if not sym or sym in SKIP:
+        return None
+    if sym in table:
+        return table[sym]
+    # Direct Unicode forms used throughout the symbol files.
+    m = re.fullmatch(r"0x100([0-9a-fA-F]{4})", sym)
+    if not m:
+        m = re.fullmatch(r"U([0-9a-fA-F]{4,6})", sym)
+    if m:
+        ch = chr(int(m.group(1), 16))
+        # A combining mark needs something to combine with, or it lands on the key label
+        # before it and looks like a rendering bug.
+        return ("◌" + ch) if 0x0300 <= ord(ch) <= 0x036F else ch
+    if len(sym) == 1:
+        return sym
+    return None
+
+
+class Symbols:
+    """Reads a symbol file and resolves its include chain the way xkbcomp would."""
+
+    def __init__(self, src, fetch_missing):
+        self.src = src
+        self.fetch_missing = fetch_missing
+        self.cache = {}
+
+    def _text(self, name):
+        if name in self.cache:
+            return self.cache[name]
+        path = os.path.join(self.src, name)
+        if not os.path.exists(path) and self.fetch_missing:
+            try:
+                fetch(XKB_BASE + name, path)
+            except Exception as ex:
+                print(f"  ! cannot fetch symbols/{name}: {ex}", file=sys.stderr)
+        try:
+            with open(path, encoding="utf-8", errors="replace") as f:
+                text = f.read()
+        except Exception:
+            text = ""
+        self.cache[name] = text
+        return text
+
+    def block(self, name, variant=None):
+        """The body of one xkb_symbols block — the named variant, else the default."""
+        text = self._text(name)
+        if not text:
+            return ""
+        best = None
+        for m in _BLOCK_RE.finditer(text):
+            is_default, vname = m.group(1), m.group(2)
+            if variant is not None and vname != variant:
+                continue
+            if variant is None and not is_default and best is not None:
+                continue
+            start = m.end()
+            depth, i = 1, start
+            while i < len(text) and depth:
+                if text[i] == "{":
+                    depth += 1
+                elif text[i] == "}":
+                    depth -= 1
+                i += 1
+            body = text[start:i - 1]
+            if variant is not None or is_default:
+                return body
+            if best is None:
+                best = body
+        return best or ""
+
+    def levels(self, name, variant=None, seen=None):
+        """{xkb key name: [level1, level2, level3, ...]} with includes merged in first."""
+        seen = seen if seen is not None else set()
+        key = (name, variant)
+        if key in seen:
+            return {}
+        seen.add(key)
+        body = self.block(name, variant)
+        out = {}
+        for inc in _INCLUDE_RE.findall(body):
+            m = re.fullmatch(r"([\w+/-]+)(?:\(([\w-]+)\))?", inc.strip())
+            if not m:
+                continue
+            out.update(self.levels(m.group(1), m.group(2), seen))
+        for kname, spec in _KEY_RE.findall(body):
+            # A key may declare its type before its symbols:
+            #   key <AD08> { type[group1] = "FOUR_LEVEL_ALPHABETIC", [ i, I, ... ] };
+            # and that bracket is not a symbol list. Turkish writes its dotted/dotless i
+            # exactly this way, which is a good reminder to strip these first.
+            spec = _TYPE_RE.sub("", spec)
+            groups = _GROUP_RE.findall(spec)
+            if not groups:
+                continue
+            syms = [s.strip() for s in groups[0].split(",")]
+            # A redefinition overrides the included one level by level, and `any` at a
+            # level means "leave that one alone". Greek is written this way: it includes
+            # gr(simple) for the letters and then redefines only levels 3 and 4, so
+            # replacing the whole entry would throw the alphabet away.
+            old = out.get(kname, [])
+            merged = list(syms)
+            for i, s in enumerate(merged):
+                if s in ("any", "NoSymbol", "") and i < len(old):
+                    merged[i] = old[i]
+            if len(old) > len(merged):
+                merged += old[len(merged):]
+            out[kname] = merged
+        return out
+
+
+def build(code, syms, table):
+    levels = syms.levels(code)
+    out = {}
+    for xkbname, entry in levels.items():
+        evdev = XKB_TO_EVDEV.get(xkbname)
+        if not evdev:
+            continue
+        chars = [keysym_char(s, table) for s in entry[:4]]
+        label = chars[0] if len(chars) > 0 else None
+        shifted = chars[1] if len(chars) > 1 else None
+        alt = chars[2] if len(chars) > 2 else None
+        if label is None:
+            continue
+        rec = {"label": label}
+        # A shift level that just upper-cases the letter is what every keyboard does;
+        # printing it in the corner of the key is noise.
+        if shifted and shifted != label and shifted != label.upper():
+            rec["shifted"] = shifted
+        if alt and alt not in (label, shifted):
+            rec["alt"] = alt
+        out[evdev] = rec
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", default=os.path.join(HERE, ".xkb"),
+                    help="xkb data dir (a checkout, or /usr/share/X11/xkb)")
+    ap.add_argument("--fetch", action="store_true",
+                    help="download missing symbol files from xkeyboard-config")
+    args = ap.parse_args()
+
+    symdir = args.src
+    if os.path.isdir(os.path.join(symdir, "symbols")):
+        symdir = os.path.join(symdir, "symbols")
+    os.makedirs(symdir, exist_ok=True)
+
+    keysymdef = os.path.join(args.src, "keysymdef.h")
+    if not os.path.exists(keysymdef):
+        for candidate in ("/usr/include/X11/keysymdef.h",):
+            if os.path.exists(candidate):
+                keysymdef = candidate
+                break
+        else:
+            if not args.fetch:
+                sys.exit("no keysymdef.h — pass --fetch, or --src a tree containing it")
+            fetch(KEYSYMDEF, keysymdef)
+    table = load_keysyms(keysymdef)
+    print(f"keysyms: {len(table)}")
+
+    syms = Symbols(symdir, args.fetch)
+    os.makedirs(OUT, exist_ok=True)
+    index = {}
+    for code, name in LAYOUTS:
+        data = build(code, syms, table)
+        if len(data) < 20:
+            print(f"  ! {code}: only {len(data)} keys resolved — not written",
+                  file=sys.stderr)
+            continue
+        with open(os.path.join(OUT, f"{code}.json"), "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False, sort_keys=True)
+            f.write("\n")
+        index[code] = name
+        alt = sum(1 for v in data.values() if "alt" in v)
+        print(f"  {code:6s} {len(data):3d} keys, {alt:3d} with AltGr  — {name}")
+
+    with open(os.path.join(OUT, "index.json"), "w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2, ensure_ascii=False, sort_keys=True)
+        f.write("\n")
+    print(f"wrote {len(index)} locales to {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -15,6 +15,7 @@ rm -f "$HOME/.local/bin/handheld-kbd.py" \
       "$HOME/.local/bin/handheld-kbd-relogin" \
       "$HOME/.local/bin/handheld-kbd-ip-remap" \
       "$HOME/.local/bin/handheld-kbd-ctl" \
+      "$HOME/.local/bin/handheld-kbd-locales" \
       "$HOME/.config/autostart/handheld-kbd.desktop" \
       "$HOME/.config/autostart/handheld-kbd-swap.desktop"
 rm -f "$HOME"/.local/share/applications/handheld-kbd-*.desktop


### PR DESCRIPTION
Closes #13 (Italian), and adds the Vietnamese that was asked for alongside it.

## What was actually missing

The keyboard injects real keycodes, so what a key *types* has always been decided by the OS layout. With only `us`/`gb` label files, selecting a Russian layout typed Cyrillic correctly while drawing `q` on the key that produces `й`. The gap was never in typing — it was the keyboard refusing to admit what the OS was doing.

## Twenty layouts

English (US/UK), German, French, Spanish (Spain and Latin America), Italian, Portuguese (Portugal and Brazil), Dutch, Polish, Turkish, Russian, Ukrainian, Greek, Arabic, Hebrew, Hindi (Devanagari), Thai, Vietnamese.

Generated by `tools/build-locales.py` from [xkeyboard-config](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config) symbol files and xorgproto's `keysymdef.h`, and committed so an install needs no network and no xkb parsing. Hand-typing them would have been twenty chances to be subtly wrong in scripts I can't proofread.

Three things the parser has to get right, each found by a layout that broke without it:

- **Include resolution** — `vn` includes `us`, `tr` includes `latin`, and so on down the chain.
- **Level-by-level merge** — Greek includes `gr(simple)` for its alphabet and then redefines only levels 3 and 4, using `any` for the first two. Replacing the whole entry threw the alphabet away and left 4 keys.
- **Stripping type declarations** — `key <AD08> { type[group1] = "FOUR_LEVEL_ALPHABETIC", [ i, I, ... ] }`. That first bracket is not a symbol list. Turkish writes its dotted/dotless `i` exactly this way, and lost the key entirely.

Spot-checked: Italian `ò ç @`, French AZERTY, German `y`/`z` swapped, Turkish `ı` on the I key with `İ` shifted on the apostrophe, Greek `α σ`, Russian `й ф я`, GB `£` on 3 with `€` on AltGr-4.

## AltGr

Most non-English layouts keep a third of their characters on the third level — Polish `ą`, French `@`, Turkish `î`, Italian `[`. Without the key they were unreachable, so "supports Italian" would have been half true at best.

Holding AltGr re-skins the keys to show what they'll type. The alternative was three glyphs per key, which on a 7-inch panel is unreadable — and most layouts have an AltGr symbol on nearly every key. Existing installs get the key merged into their layout on upgrade, next to the action-key merge that was already there.

## `handheld-kbd-locales`

🌐 asks KDE for its next layout, so it can only reach layouts KDE has been told about — with one configured it has nowhere to go. This edits the list, reports which layouts have labels, and says plainly that KDE reads the list at session start.

## What this deliberately doesn't do

- **Chinese, Japanese, Korean.** Input methods, not keyboard layouts. No mapping of keycodes to characters produces them. Fcitx and IBus work with this keyboard as with any other, because the keystrokes are real.
- **Vietnamese, honestly.** The `vn` layout puts `ă â ê ô ơ ư đ` on the number row and tone marks on `5`–`9` — costing the digits, and still unable to produce every syllable. Most Vietnamese typing uses an IME over a US layout. Shipped for those who want it, documented for those who don't.

## Pre-release

Tagging `v1.0.11-rc1`. The mechanism is tested; the individual layouts are not, and I can proofread Latin, Cyrillic and Greek and no further. Arabic, Hebrew, Devanagari and Thai need someone who reads them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)