### PR TITLE
System tray icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ proofreader for Arabic, Hebrew, Devanagari and Thai. Corrections very welcome.
   than printing three glyphs on a key the size of a fingernail. Existing installs get the
   key added to their layout on upgrade.
 
+- **A system tray icon.** Tap it to show or hide the keyboard; right-click for restart,
+  reset position, fix the trackpad pointer, and stop/start. The Show/Hide and Stop/Start
+  entries say which one they'll do, rather than offering you the dead half of the pair.
+
+  It speaks the StatusNotifierItem and DBusMenu protocols to Plasma directly rather than
+  going through libappindicator — SteamOS is an immutable image with no pip and no
+  appindicator package, so a dependency here would be one that cannot be installed. It
+  runs as its own process, because its whole job is rescuing a misbehaving keyboard and
+  "Restart" shouldn't mean killing yourself mid-click. The supervisor keeps it alive, so
+  a Plasma restart doesn't take it away for good.
+
 - **`handheld-kbd-locales`** — list, add, remove or set the layouts KDE offers, since
   🌐 can only reach layouts KDE has been told about, and with one configured it has
   nowhere to go. Reports which have labels and which don't, and reminds you that KDE

--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ So I built the keyboard I wanted instead. Here's what it does differently:
   one — and while Steam thinks its keyboard is open, the sticks and trackpads navigate
   *that* instead of moving the pointer. Steam's keyboard is closed rather than hidden, so
   the pointer stays yours.
-- **Shortcuts for when it goes wrong.** Show/hide, restart, stop, reset position and fix
-  the trackpad pointer all appear in the application menu — clickable, because typing is
-  the one thing you can't do when the keyboard is the problem.
+- **A tray icon.** Tap to show or hide; right-click for restart, reset position, fix the
+  trackpad pointer, stop and start.
+- **Shortcuts for when it goes wrong.** The same actions appear in the application menu —
+  clickable, because typing is the one thing you can't do when the keyboard is the
+  problem.
 - **Swipe typing.** Drag across the letters instead of tapping them. Taps are
   unaffected — a drag only counts once it's unmistakably not one.
 - **Optional summon gestures.** Two-finger swipe up from the bottom edge
@@ -125,6 +127,10 @@ Or click **Fix Trackpad and Stick Pointer** in the application menu. It closes t
 window; no Steam restart, no relogin.
 
 ## Controlling it
+
+The tray icon is the quickest route: tap to show or hide, right-click for the rest. If it
+isn't in your system tray, Plasma may be hiding it — check the tray's overflow arrow, or
+its settings. `handheld-kbd-tray` starts it by hand.
 
 ```bash
 handheld-kbd-ctl status      # what's running, and where the keyboard is

--- a/autostart/handheld-kbd-tray.desktop
+++ b/autostart/handheld-kbd-tray.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Application
+Name=Better Handheld Keyboard Tray
+Exec=__BIN__/handheld-kbd-tray
+X-GNOME-Autostart-enabled=true

--- a/bin/handheld-kbd-swap.sh
+++ b/bin/handheld-kbd-swap.sh
@@ -137,6 +137,13 @@ while true; do
         fi
     fi
 
+    # The tray icon is the way back when the keyboard misbehaves, so it is the last
+    # thing that should be missing. Plasma restarts take it with them.
+    if [ -x "$HOME/.local/bin/handheld-kbd-tray" ] \
+       && ! pgrep -f 'python3 .*handheld-kbd-tray' >/dev/null; then
+        setsid python3 "$HOME/.local/bin/handheld-kbd-tray" </dev/null >>/tmp/handheld-kbd-tray.log 2>&1 &
+    fi
+
     # Watchdog: the keyboard's Wayland connection drops when Steam restarts or the
     # compositor churns. Respawn it hidden so the next summon is instant.
     if ! pgrep -f 'python3 .*handheld-kbd\.py' >/dev/null; then

--- a/bin/handheld-kbd-tray
+++ b/bin/handheld-kbd-tray
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""System tray icon: show/hide the keyboard, restart it, put it back.
+
+A separate process from the keyboard on purpose. The tray's whole job is to rescue a
+keyboard that is misbehaving, so it must not share a process with the thing it rescues —
+and clicking "Restart" would otherwise mean killing yourself mid-click.
+
+This talks the StatusNotifierItem protocol to Plasma directly over DBus, rather than
+through libappindicator. SteamOS is an immutable image with no pip and no appindicator
+package, so a dependency here is a dependency that cannot be installed.
+
+    handheld-kbd-tray            run it (normally started by autostart)
+"""
+import os
+import signal
+import subprocess
+import sys
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gio, GLib     # noqa: E402
+
+BIN = os.path.expanduser("~/.local/bin")
+APP_ID = f"handheld-kbd-tray-{os.getpid()}"
+BUS_NAME = f"org.kde.StatusNotifierItem-{os.getpid()}-1"
+ITEM_PATH = "/StatusNotifierItem"
+MENU_PATH = "/MenuBar"
+
+SNI_XML = """
+<node>
+  <interface name='org.kde.StatusNotifierItem'>
+    <property name='Category' type='s' access='read'/>
+    <property name='Id' type='s' access='read'/>
+    <property name='Title' type='s' access='read'/>
+    <property name='Status' type='s' access='read'/>
+    <property name='IconName' type='s' access='read'/>
+    <property name='ToolTip' type='(sa(iiay)ss)' access='read'/>
+    <property name='Menu' type='o' access='read'/>
+    <property name='ItemIsMenu' type='b' access='read'/>
+    <method name='Activate'>
+      <arg type='i' name='x' direction='in'/>
+      <arg type='i' name='y' direction='in'/>
+    </method>
+    <method name='SecondaryActivate'>
+      <arg type='i' name='x' direction='in'/>
+      <arg type='i' name='y' direction='in'/>
+    </method>
+    <method name='ContextMenu'>
+      <arg type='i' name='x' direction='in'/>
+      <arg type='i' name='y' direction='in'/>
+    </method>
+    <method name='Scroll'>
+      <arg type='i' name='delta' direction='in'/>
+      <arg type='s' name='orientation' direction='in'/>
+    </method>
+    <signal name='NewIcon'/>
+    <signal name='NewStatus'><arg type='s' name='status'/></signal>
+    <signal name='NewToolTip'/>
+  </interface>
+</node>
+"""
+
+# The menu half of the protocol. Plasma asks for the layout, we answer with a tree, and
+# it tells us which id was clicked.
+MENU_XML = """
+<node>
+  <interface name='com.canonical.dbusmenu'>
+    <property name='Version' type='u' access='read'/>
+    <property name='Status' type='s' access='read'/>
+    <property name='TextDirection' type='s' access='read'/>
+    <property name='IconThemePath' type='as' access='read'/>
+    <method name='GetLayout'>
+      <arg type='i' name='parentId' direction='in'/>
+      <arg type='i' name='recursionDepth' direction='in'/>
+      <arg type='as' name='propertyNames' direction='in'/>
+      <arg type='u' name='revision' direction='out'/>
+      <arg type='(ia{sv}av)' name='layout' direction='out'/>
+    </method>
+    <method name='GetGroupProperties'>
+      <arg type='ai' name='ids' direction='in'/>
+      <arg type='as' name='propertyNames' direction='in'/>
+      <arg type='a(ia{sv})' name='properties' direction='out'/>
+    </method>
+    <method name='GetProperty'>
+      <arg type='i' name='id' direction='in'/>
+      <arg type='s' name='name' direction='in'/>
+      <arg type='v' name='value' direction='out'/>
+    </method>
+    <method name='Event'>
+      <arg type='i' name='id' direction='in'/>
+      <arg type='s' name='eventId' direction='in'/>
+      <arg type='v' name='data' direction='in'/>
+      <arg type='u' name='timestamp' direction='in'/>
+    </method>
+    <method name='AboutToShow'>
+      <arg type='i' name='id' direction='in'/>
+      <arg type='b' name='needUpdate' direction='out'/>
+    </method>
+    <signal name='LayoutUpdated'>
+      <arg type='u' name='revision'/>
+      <arg type='i' name='parent'/>
+    </signal>
+  </interface>
+</node>
+"""
+
+
+def run(*args):
+    """Fire and forget: a tray click must never block the panel waiting for us."""
+    try:
+        subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                         start_new_session=True)
+    except Exception as ex:
+        print(f"handheld-kbd-tray: {args[0]} failed ({ex})", file=sys.stderr)
+
+
+def kbd_running():
+    return subprocess.run(["pgrep", "-f", r"python3 .*handheld-kbd\.py"],
+                          stdout=subprocess.DEVNULL).returncode == 0
+
+
+def kbd_shown():
+    try:
+        with open("/tmp/handheld-kbd.vis") as f:
+            return f.read().strip() == "1"
+    except Exception:
+        return False
+
+
+class Tray:
+    # id: (label, icon, action). 0 is the root, which dbusmenu reserves.
+    ACTIONS = {
+        1: ("Show keyboard",         "input-keyboard",  lambda: run(f"{BIN}/handheld-kbd-toggle")),
+        3: ("Restart keyboard",      "view-refresh",    lambda: run(f"{BIN}/handheld-kbd-ctl", "restart")),
+        4: ("Reset position",        "go-bottom",       lambda: run(f"{BIN}/handheld-kbd-ctl", "reset")),
+        5: ("Fix trackpad pointer",  "input-touchpad",  lambda: run(f"{BIN}/handheld-kbd-fix-pointer")),
+        7: ("Stop keyboard",         "process-stop",    lambda: run(f"{BIN}/handheld-kbd-ctl", "stop")),
+    }
+    SEPARATORS = (2, 6)
+
+    def __init__(self):
+        self.bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        self.revision = 1
+
+    # ---- menu model ----
+
+    def label(self, item_id):
+        text = self.ACTIONS[item_id][0]
+        if item_id == 1:
+            # One entry, not two: "Hide" on a hidden keyboard is a dead option, and a
+            # tray menu is read at a glance.
+            return "Hide keyboard" if kbd_shown() else "Show keyboard"
+        if item_id == 7 and not kbd_running():
+            return "Start keyboard"
+        return text
+
+    def props(self, item_id):
+        if item_id in self.SEPARATORS:
+            return {"type": GLib.Variant("s", "separator")}
+        label, icon, _ = self.ACTIONS[item_id]
+        return {
+            "label": GLib.Variant("s", self.label(item_id)),
+            "icon-name": GLib.Variant("s", icon),
+            "enabled": GLib.Variant("b", True),
+            "visible": GLib.Variant("b", True),
+        }
+
+    def node(self, item_id):
+        return GLib.Variant("(ia{sv}av)", (item_id, self.props(item_id), []))
+
+    def layout(self):
+        kids = [self.node(i) for i in sorted(list(self.ACTIONS) + list(self.SEPARATORS))]
+        root = {"children-display": GLib.Variant("s", "submenu")}
+        return GLib.Variant("(ia{sv}av)", (0, root, kids))
+
+    # ---- dbus plumbing ----
+
+    def on_sni_call(self, conn, sender, path, iface, method, params, inv):
+        if method in ("Activate", "SecondaryActivate"):
+            run(f"{BIN}/handheld-kbd-toggle")
+        inv.return_value(None)
+
+    def on_sni_get(self, conn, sender, path, iface, prop):
+        return {
+            "Category": GLib.Variant("s", "SystemServices"),
+            "Id": GLib.Variant("s", "handheld-kbd"),
+            "Title": GLib.Variant("s", "Handheld Keyboard"),
+            "Status": GLib.Variant("s", "Active"),
+            "IconName": GLib.Variant("s", "input-keyboard"),
+            "ToolTip": GLib.Variant("(sa(iiay)ss)",
+                                    ("input-keyboard", [], "Handheld Keyboard",
+                                     "Tap to show or hide the keyboard")),
+            "Menu": GLib.Variant("o", MENU_PATH),
+            "ItemIsMenu": GLib.Variant("b", False),
+        }.get(prop)
+
+    def on_menu_call(self, conn, sender, path, iface, method, params, inv):
+        if method == "GetLayout":
+            inv.return_value(GLib.Variant.new_tuple(
+                GLib.Variant("u", self.revision), self.layout()))
+        elif method == "GetGroupProperties":
+            ids = params.unpack()[0]
+            wanted = ids or sorted(list(self.ACTIONS) + list(self.SEPARATORS))
+            inv.return_value(GLib.Variant("(a(ia{sv}))", ([
+                (i, self.props(i)) for i in wanted
+                if i in self.ACTIONS or i in self.SEPARATORS], )))
+        elif method == "GetProperty":
+            item_id, name = params.unpack()
+            value = self.props(item_id).get(name, GLib.Variant("s", ""))
+            inv.return_value(GLib.Variant.new_tuple(GLib.Variant("v", value)))
+        elif method == "Event":
+            item_id, event_id = params.unpack()[0], params.unpack()[1]
+            inv.return_value(None)
+            if event_id == "clicked" and item_id in self.ACTIONS:
+                self.ACTIONS[item_id][2]()
+                # State changes after every one of these, so the next open re-reads it.
+                GLib.timeout_add_seconds(1, self.refresh)
+            return
+        elif method == "AboutToShow":
+            # Labels depend on whether the keyboard is up and shown right now.
+            inv.return_value(GLib.Variant("(b)", (True,)))
+            self.refresh()
+            return
+        else:
+            inv.return_value(None)
+
+    def on_menu_get(self, conn, sender, path, iface, prop):
+        return {
+            "Version": GLib.Variant("u", 3),
+            "Status": GLib.Variant("s", "normal"),
+            "TextDirection": GLib.Variant("s", "ltr"),
+            "IconThemePath": GLib.Variant("as", []),
+        }.get(prop)
+
+    def refresh(self):
+        self.revision += 1
+        try:
+            self.bus.emit_signal(None, MENU_PATH, "com.canonical.dbusmenu",
+                                 "LayoutUpdated",
+                                 GLib.Variant("(ui)", (self.revision, 0)))
+        except Exception:
+            pass
+        return False
+
+    def register(self):
+        for path, xml, call, get in (
+                (ITEM_PATH, SNI_XML, self.on_sni_call, self.on_sni_get),
+                (MENU_PATH, MENU_XML, self.on_menu_call, self.on_menu_get)):
+            node = Gio.DBusNodeInfo.new_for_xml(xml)
+            self.bus.register_object(path, node.interfaces[0], call, get, None)
+
+    def announce(self):
+        """Tell Plasma we exist. The watcher may not be up yet at login, so keep trying."""
+        try:
+            self.bus.call_sync(
+                "org.kde.StatusNotifierWatcher", "/StatusNotifierWatcher",
+                "org.kde.StatusNotifierWatcher", "RegisterStatusNotifierItem",
+                GLib.Variant("(s)", (BUS_NAME,)), None,
+                Gio.DBusCallFlags.NONE, 3000, None)
+            return False
+        except Exception:
+            return True          # try again on the next tick
+
+
+def main():
+    tray = Tray()
+
+    def on_acquired(conn, name, _user=None):
+        tray.register()
+        if tray.announce():
+            GLib.timeout_add_seconds(5, tray.announce)
+
+    Gio.bus_own_name(Gio.BusType.SESSION, BUS_NAME, Gio.BusNameOwnerFlags.NONE,
+                     on_acquired, None, None)
+
+    loop = GLib.MainLoop()
+    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM,
+                         lambda *_: (loop.quit(), False)[1], None)
+    # Plasma restarts take the watcher with them; re-announce when it comes back.
+    Gio.bus_watch_name(Gio.BusType.SESSION, "org.kde.StatusNotifierWatcher",
+                       Gio.BusNameWatcherFlags.NONE,
+                       lambda *_: tray.announce(), None)
+    loop.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,7 @@ install -m755 "$HERE/bin/handheld-kbd-install-filter" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-toggle" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-ctl" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-locales" "$BIN/"
+install -m755 "$HERE/bin/handheld-kbd-tray" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-fix-pointer" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-build-dict" "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-focus-probe" "$BIN/"
@@ -217,7 +218,9 @@ install -m755 "$HERE/bin/handheld-kbd-kwin-script" "$BIN/"
 sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd.desktop"      > "$AUTO/handheld-kbd.desktop"
 sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd-swap.desktop" > "$AUTO/handheld-kbd-swap.desktop"
 sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd-resume.desktop"   > "$AUTO/handheld-kbd-resume.desktop"
-chmod 644 "$AUTO/handheld-kbd.desktop" "$AUTO/handheld-kbd-swap.desktop" "$AUTO/handheld-kbd-resume.desktop"
+sed "s#__BIN__#$BIN#g" "$HERE/autostart/handheld-kbd-tray.desktop"     > "$AUTO/handheld-kbd-tray.desktop"
+chmod 644 "$AUTO/handheld-kbd.desktop" "$AUTO/handheld-kbd-swap.desktop" \
+          "$AUTO/handheld-kbd-resume.desktop" "$AUTO/handheld-kbd-tray.desktop"
 
 # --- application-menu shortcuts (show/hide, restart, stop, reset position) ---
 # Typing a command is the one thing you can't do when the keyboard is the problem,

--- a/shortcuts/handheld-kbd-tray.desktop
+++ b/shortcuts/handheld-kbd-tray.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Handheld Keyboard Tray Icon
+Comment=Put a keyboard icon in the system tray — tap to show or hide, right-click for more
+Icon=input-keyboard
+Terminal=false
+Exec=__BIN__/handheld-kbd-tray
+Categories=Utility;Accessibility;
+Keywords=keyboard;tray;systray;indicator;

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -16,6 +16,8 @@ rm -f "$HOME/.local/bin/handheld-kbd.py" \
       "$HOME/.local/bin/handheld-kbd-ip-remap" \
       "$HOME/.local/bin/handheld-kbd-ctl" \
       "$HOME/.local/bin/handheld-kbd-locales" \
+      "$HOME/.local/bin/handheld-kbd-tray" \
+      "$HOME/.config/autostart/handheld-kbd-tray.desktop" \
       "$HOME/.config/autostart/handheld-kbd.desktop" \
       "$HOME/.config/autostart/handheld-kbd-swap.desktop"
 rm -f "$HOME"/.local/share/applications/handheld-kbd-*.desktop


### PR DESCRIPTION
Tap to show or hide the keyboard; right-click for restart, reset position, fix the trackpad pointer, and stop/start.

The recovery actions already existed, but only as commands and application-menu entries — an awkward place for them, since the keyboard being broken is exactly when you can't type, and the app menu is several taps deep on a handheld.

**No new dependency.** It speaks StatusNotifierItem and DBusMenu to Plasma directly rather than going through libappindicator. SteamOS is an immutable image with no pip and no appindicator package, so a dependency here would be one that cannot be installed.

**Its own process.** Its whole job is rescuing a misbehaving keyboard, so sharing a process with the thing it rescues would make "Restart" mean killing yourself mid-click. The supervisor respawns it, because a Plasma restart takes the tray with it.

**Labels follow state.** Show/Hide and Stop/Start read the live state and name the action they'll take, instead of showing both halves with one of them dead.

Verified on a Legion Go 2:

```
RegisteredStatusNotifierItems: … "org.kde.StatusNotifierItem-10335-1/StatusNotifierItem"
GetLayout: 7 items — Show keyboard / — / Restart keyboard / Reset position /
           Fix trackpad pointer / — / Stop keyboard
Event(1, "clicked") → vis=1 … Event(1, "clicked") → vis=0
```

Goes into the v1.0.11 pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)