### PR TITLE
Fix tray Restart killing itself, and complete all twenty layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,21 @@ proofreader for Arabic, Hebrew, Devanagari and Thai. Corrections very welcome.
   They are generated from [xkeyboard-config](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config)
   and xorgproto's `keysymdef.h` by `tools/build-locales.py`, and committed. Typing them
   out by hand would have been twenty chances to be subtly wrong in scripts I cannot
-  proofread.
+  proofread. All twenty resolve all 47 keys — anything less is treated as a parser bug,
+  which is how these were found:
+
+  - Comments were counted when scanning for the end of a block. These files annotate keys
+    with the characters they produce, and those annotations contain braces —
+    `key <AB03> {[...]};  // ؤ }` — so the Arabic layout ended after three keys and
+    silently lost the other seven, leaving `v b n m , . /` drawn in Latin.
+  - Keysyms were resolved by their own `U+` comment, but several names share a code and
+    only one carries the annotation; the rest read "deprecated alias for …". That lost
+    `masculine` and `guillemotleft`, and with them `º` on the Spanish layout and `«` `»`
+    on the Portuguese one. Resolution now goes through the keysym code.
+  - Greek redefines only levels 3 and 4 over `gr(simple)` using `any` for the first two,
+    so replacing whole entries threw the alphabet away — levels merge individually now.
+  - `key <AD08> { type[group1] = "…", [ i, I ] }` — that first bracket is not a symbol
+    list, and taking it lost Turkish's dotted/dotless `i`.
 
 - **AltGr.** Most non-English layouts keep a third of their characters on the third level
   — Polish `ą`, French `@`, Turkish `î`, Italian `[` — and without an AltGr key they were
@@ -48,6 +62,14 @@ proofreader for Arabic, Hebrew, Devanagari and Thai. Corrections very welcome.
   runs as its own process, because its whole job is rescuing a misbehaving keyboard and
   "Restart" shouldn't mean killing yourself mid-click. The supervisor keeps it alive, so
   a Plasma restart doesn't take it away for good.
+
+  Its own process turned out not to be enough. The supervisor runs as a transient systemd
+  unit, and stopping a unit stops its whole cgroup — which contained the tray *and* the
+  restart script the tray had just launched. The stop half ran, the start half never did,
+  and the keyboard did not come back. `start_new_session()` does not help; a cgroup is not
+  a session. The tray is now a unit in its own right, and `handheld-kbd-ctl` re-runs
+  itself in a transient unit before touching anything, so it cannot be killed by the stop
+  it just issued.
 
 - **`handheld-kbd-locales`** — list, add, remove or set the layouts KDE offers, since
   🌐 can only reach layouts KDE has been told about, and with one configured it has

--- a/bin/handheld-kbd-ctl
+++ b/bin/handheld-kbd-ctl
@@ -21,6 +21,25 @@ SUP_PAT='handheld-kbd-swap\.sh'
 
 export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 
+# Get out of the keyboard's own cgroup before touching it.
+#
+# The supervisor runs as a transient systemd unit, and the tray is one of its children —
+# so is this script when the tray launches it. Stopping that unit kills its entire cgroup,
+# which is the tray, and this script, mid-restart: the stop half ran, the start half never
+# did, and the keyboard did not come back. start_new_session() does not help; a cgroup is
+# not a session. Re-run ourselves in a transient unit of our own, which nothing here stops.
+if [ -z "${HK_DETACHED:-}" ] && command -v systemd-run >/dev/null 2>&1; then
+    case "${1:-restart}" in
+        start|stop|restart)
+            if grep -qs 'handheld-kbd' /proc/self/cgroup; then
+                exec systemd-run --user --collect --quiet --pipe \
+                     --unit="handheld-kbd-ctl-$$" --setenv=HK_DETACHED=1 \
+                     -- "$0" "$@"
+            fi
+            ;;
+    esac
+fi
+
 # Match by pattern but never kill ourselves or our own parents: `handheld-kbd-ctl`
 # run from a shell whose argv mentions the pattern would otherwise take the shell
 # with it, which is a memorable way to lose an SSH session.

--- a/bin/handheld-kbd-swap.sh
+++ b/bin/handheld-kbd-swap.sh
@@ -139,9 +139,16 @@ while true; do
 
     # The tray icon is the way back when the keyboard misbehaves, so it is the last
     # thing that should be missing. Plasma restarts take it with them.
+    # Started as its own systemd unit, not as our child: stopping this supervisor stops
+    # its whole cgroup, and the tray is the one thing that must survive a keyboard
+    # restart — it is where the user clicked "Restart" from.
     if [ -x "$HOME/.local/bin/handheld-kbd-tray" ] \
        && ! pgrep -f 'python3 .*handheld-kbd-tray' >/dev/null; then
-        setsid python3 "$HOME/.local/bin/handheld-kbd-tray" </dev/null >>/tmp/handheld-kbd-tray.log 2>&1 &
+        systemctl --user reset-failed handheld-kbd-tray >/dev/null 2>&1
+        systemd-run --user --collect --quiet --unit=handheld-kbd-tray \
+            python3 "$HOME/.local/bin/handheld-kbd-tray" >/dev/null 2>&1 \
+          || setsid python3 "$HOME/.local/bin/handheld-kbd-tray" </dev/null \
+               >>/tmp/handheld-kbd-tray.log 2>&1 &
     fi
 
     # Watchdog: the keyboard's Wayland connection drops when Steam restarts or the

--- a/config/locales/ara.json
+++ b/config/locales/ara.json
@@ -58,6 +58,10 @@
     "label": "ط",
     "shifted": "\""
   },
+  "KEY_B": {
+    "label": "ﻻ",
+    "shifted": "ﻵ"
+  },
   "KEY_BACKSLASH": {
     "alt": "⟨",
     "label": "\\",
@@ -67,9 +71,19 @@
     "label": "ؤ",
     "shifted": "}"
   },
+  "KEY_COMMA": {
+    "alt": "٬",
+    "label": "و",
+    "shifted": ","
+  },
   "KEY_D": {
     "label": "ي",
     "shifted": "]"
+  },
+  "KEY_DOT": {
+    "alt": "ژ",
+    "label": "ز",
+    "shifted": "."
   },
   "KEY_E": {
     "label": "ث",
@@ -121,10 +135,19 @@
     "label": "ج",
     "shifted": "<"
   },
+  "KEY_M": {
+    "label": "ة",
+    "shifted": "'"
+  },
   "KEY_MINUS": {
     "alt": "–",
     "label": "-",
     "shifted": "_"
+  },
+  "KEY_N": {
+    "alt": "ٰ",
+    "label": "ى",
+    "shifted": "آ"
   },
   "KEY_O": {
     "label": "خ",
@@ -155,6 +178,11 @@
     "label": "ك",
     "shifted": ":"
   },
+  "KEY_SLASH": {
+    "alt": "٭",
+    "label": "ظ",
+    "shifted": "؟"
+  },
   "KEY_T": {
     "alt": "ڤ",
     "label": "ف",
@@ -164,11 +192,16 @@
     "label": "ع",
     "shifted": "`"
   },
+  "KEY_V": {
+    "label": "ر",
+    "shifted": "{"
+  },
   "KEY_W": {
     "label": "ص",
     "shifted": "ً"
   },
   "KEY_X": {
+    "alt": "«",
     "label": "ء",
     "shifted": "ْ"
   },
@@ -177,6 +210,7 @@
     "shifted": "إ"
   },
   "KEY_Z": {
+    "alt": "»",
     "label": "ئ",
     "shifted": "~"
   }

--- a/config/locales/br.json
+++ b/config/locales/br.json
@@ -63,6 +63,7 @@
     "label": "b"
   },
   "KEY_BACKSLASH": {
+    "alt": "º",
     "label": "]",
     "shifted": "}"
   },
@@ -194,6 +195,7 @@
     "label": "w"
   },
   "KEY_X": {
+    "alt": "»",
     "label": "x"
   },
   "KEY_Y": {
@@ -201,6 +203,7 @@
     "label": "y"
   },
   "KEY_Z": {
+    "alt": "«",
     "label": "z"
   }
 }

--- a/config/locales/de.json
+++ b/config/locales/de.json
@@ -194,6 +194,7 @@
     "label": "w"
   },
   "KEY_X": {
+    "alt": "«",
     "label": "x"
   },
   "KEY_Y": {
@@ -201,6 +202,7 @@
     "label": "z"
   },
   "KEY_Z": {
+    "alt": "»",
     "label": "y"
   }
 }

--- a/config/locales/es.json
+++ b/config/locales/es.json
@@ -101,6 +101,11 @@
     "alt": "ŋ",
     "label": "g"
   },
+  "KEY_GRAVE": {
+    "alt": "\\",
+    "label": "º",
+    "shifted": "ª"
+  },
   "KEY_H": {
     "alt": "ħ",
     "label": "h"
@@ -190,6 +195,7 @@
     "label": "w"
   },
   "KEY_X": {
+    "alt": "»",
     "label": "x"
   },
   "KEY_Y": {
@@ -197,6 +203,7 @@
     "label": "y"
   },
   "KEY_Z": {
+    "alt": "«",
     "label": "z"
   }
 }

--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -192,9 +192,11 @@
     "label": "v"
   },
   "KEY_W": {
+    "alt": "«",
     "label": "z"
   },
   "KEY_X": {
+    "alt": "»",
     "label": "x"
   },
   "KEY_Y": {

--- a/config/locales/gb.json
+++ b/config/locales/gb.json
@@ -196,6 +196,7 @@
     "label": "w"
   },
   "KEY_X": {
+    "alt": "»",
     "label": "x"
   },
   "KEY_Y": {
@@ -203,6 +204,7 @@
     "label": "y"
   },
   "KEY_Z": {
+    "alt": "«",
     "label": "z"
   }
 }

--- a/config/locales/gr.json
+++ b/config/locales/gr.json
@@ -71,6 +71,7 @@
     "label": "ψ"
   },
   "KEY_COMMA": {
+    "alt": "«",
     "label": ",",
     "shifted": "<"
   },
@@ -79,6 +80,7 @@
     "label": "δ"
   },
   "KEY_DOT": {
+    "alt": "»",
     "label": ".",
     "shifted": ">"
   },

--- a/config/locales/it.json
+++ b/config/locales/it.json
@@ -197,6 +197,7 @@
     "label": "w"
   },
   "KEY_X": {
+    "alt": "»",
     "label": "x"
   },
   "KEY_Y": {
@@ -204,6 +205,7 @@
     "label": "y"
   },
   "KEY_Z": {
+    "alt": "«",
     "label": "z"
   }
 }

--- a/config/locales/latam.json
+++ b/config/locales/latam.json
@@ -195,6 +195,7 @@
     "label": "w"
   },
   "KEY_X": {
+    "alt": "»",
     "label": "x"
   },
   "KEY_Y": {
@@ -202,6 +203,7 @@
     "label": "y"
   },
   "KEY_Z": {
+    "alt": "«",
     "label": "z"
   }
 }

--- a/config/locales/nl.json
+++ b/config/locales/nl.json
@@ -197,6 +197,7 @@
     "label": "w"
   },
   "KEY_X": {
+    "alt": "»",
     "label": "x"
   },
   "KEY_Y": {
@@ -204,6 +205,7 @@
     "label": "y"
   },
   "KEY_Z": {
+    "alt": "«",
     "label": "z"
   }
 }

--- a/config/locales/pl.json
+++ b/config/locales/pl.json
@@ -1,5 +1,6 @@
 {
   "KEY_0": {
+    "alt": "»",
     "label": "0",
     "shifted": ")"
   },
@@ -44,6 +45,7 @@
     "shifted": "*"
   },
   "KEY_9": {
+    "alt": "«",
     "label": "9",
     "shifted": "("
   },

--- a/config/locales/pt.json
+++ b/config/locales/pt.json
@@ -53,6 +53,11 @@
     "alt": "æ",
     "label": "a"
   },
+  "KEY_APOSTROPHE": {
+    "alt": "ˆ",
+    "label": "º",
+    "shifted": "ª"
+  },
   "KEY_B": {
     "alt": "“",
     "label": "b"
@@ -83,6 +88,11 @@
   "KEY_E": {
     "alt": "€",
     "label": "e"
+  },
+  "KEY_EQUAL": {
+    "alt": "¸",
+    "label": "«",
+    "shifted": "»"
   },
   "KEY_F": {
     "alt": "đ",
@@ -186,6 +196,7 @@
     "label": "w"
   },
   "KEY_X": {
+    "alt": "»",
     "label": "x"
   },
   "KEY_Y": {
@@ -193,6 +204,7 @@
     "label": "y"
   },
   "KEY_Z": {
+    "alt": "«",
     "label": "z"
   }
 }

--- a/config/locales/tr.json
+++ b/config/locales/tr.json
@@ -185,6 +185,7 @@
     "label": "w"
   },
   "KEY_X": {
+    "alt": "»",
     "label": "x"
   },
   "KEY_Y": {
@@ -192,6 +193,7 @@
     "label": "y"
   },
   "KEY_Z": {
+    "alt": "«",
     "label": "z"
   }
 }

--- a/config/locales/ua.json
+++ b/config/locales/ua.json
@@ -40,6 +40,7 @@
     "shifted": "?"
   },
   "KEY_8": {
+    "alt": "•",
     "label": "8",
     "shifted": "*"
   },
@@ -67,12 +68,14 @@
     "label": "с"
   },
   "KEY_COMMA": {
+    "alt": "«",
     "label": "б"
   },
   "KEY_D": {
     "label": "в"
   },
   "KEY_DOT": {
+    "alt": "»",
     "label": "ю"
   },
   "KEY_E": {

--- a/tools/build-locales.py
+++ b/tools/build-locales.py
@@ -115,14 +115,39 @@ def fetch(url, path):
 
 
 def load_keysyms(path):
-    """keysym name -> character, from keysymdef.h's U+XXXX comments."""
-    table = {}
-    pat = re.compile(r"^#define\s+XK_(\w+)\s+0x[0-9a-fA-F]+\s*/\*[<\s]*U\+([0-9A-Fa-f]{4,6})")
+    """keysym name -> character, from keysymdef.h.
+
+    Resolution goes through the keysym *code*, not the name's own comment. Several names
+    share a code, and only one of them carries the U+ annotation — the others say things
+    like "deprecated alias for guillemetleft (misspelling)". Reading comments alone lost
+    `masculine`, `guillemotleft` and `guillemotright`, and with them the º key on the
+    Spanish layout and « » on the Portuguese one, because a key whose first level does
+    not resolve is dropped entirely.
+    """
+    define = re.compile(r"^#define\s+XK_(\w+)\s+0x([0-9a-fA-F]+)")
+    unicode_note = re.compile(r"/\*[(<\s]*U\+([0-9A-Fa-f]{4,6})")
+    names, code_char = {}, {}
     with open(path, encoding="utf-8", errors="replace") as f:
         for line in f:
-            m = pat.match(line)
-            if m:
-                table[m.group(1)] = chr(int(m.group(2), 16))
+            m = define.match(line)
+            if not m:
+                continue
+            name, code = m.group(1), int(m.group(2), 16)
+            names[name] = code
+            u = unicode_note.search(line)
+            if u:
+                code_char.setdefault(code, chr(int(u.group(1), 16)))
+
+    table = {}
+    for name, code in names.items():
+        ch = code_char.get(code)
+        if ch is None and 0x20 <= code <= 0xFF:
+            # Latin-1 keysyms are their own code points, by definition.
+            ch = chr(code)
+        if ch is None and code & 0xFF000000 == 0x01000000:
+            ch = chr(code & 0x00FFFFFF)
+        if ch is not None:
+            table[name] = ch
     table.update(DEAD_KEYS)
     return table
 
@@ -170,6 +195,12 @@ class Symbols:
                 text = f.read()
         except Exception:
             text = ""
+        # Strip comments before anything else looks at the text. These files annotate keys
+        # with the characters they produce, and those annotations contain braces —
+        # symbols/ara has `key <AB03> {[...]};  // ؤ }` — which the block scanner counted,
+        # ending the Arabic layout after three keys and silently losing the other seven.
+        text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+        text = re.sub(r"//[^\n]*", "", text)
         self.cache[name] = text
         return text
 


### PR DESCRIPTION
Two bugs found by testing rc2/rc3 on a Legion Go 2.

## Tray → Restart never came back

Reported: clicking Restart stopped the keyboard and nothing returned. On the device afterwards: no supervisor, no keyboard, no tray.

The supervisor runs as a transient systemd unit. The tray is one of its children, and so was `handheld-kbd-ctl` when the tray launched it. `systemctl --user stop` stops the unit's whole **cgroup** — so the stop half of the restart killed the script that was going to run the start half, and the tray with it. `start_new_session=True` doesn't help: a cgroup is not a session.

The tray is now its own unit, and `handheld-kbd-ctl` re-execs itself into a transient unit before touching anything:

```bash
if grep -qs 'handheld-kbd' /proc/self/cgroup; then
    exec systemd-run --user --collect --quiet --pipe \
         --unit="handheld-kbd-ctl-$$" --setenv=HK_DETACHED=1 -- "$0" "$@"
fi
```

Verified on the Go 2: `Event(3, "clicked")` → supervisor, keyboard and tray all present afterwards, and toggle still works.

## Arabic was missing seven keys

Spotted in a screenshot sweep — an Arabic keyboard with `v b n m , . /` in Latin.

The block scanner counted braces inside `//` comments, and these files annotate keys with what they produce:

```
key <AB03> {[ Arabic_hamzaonwaw, braceright, any, any ]};  // ؤ }
```

That `}` ended the Arabic block after three keys. Comments are stripped before anything reads the text now. 40 keys → 47.

## Spanish lost º, Portuguese lost « »

Keysyms were resolved through their own `U+` comment, but several names share a code and only one carries it:

```
#define XK_ordfeminine     0x00aa  /* U+00AA FEMININE ORDINAL INDICATOR */
#define XK_masculine       0x00ba  /* deprecated alias for ordmasculine (inconsistent name) */
```

`masculine`, `guillemotleft` and `guillemotright` resolved to nothing — and a key whose *first* level doesn't resolve is dropped entirely, so the whole key vanished rather than just a label. Resolution now goes via the keysym code, with the Latin-1 and `0x01000000` ranges as fallbacks. Keysym table 1676 → 1770 entries.

## Result

All twenty layouts resolve all 47 keys, and AltGr coverage rises with them (de 45→47, es 44→47, it 45→47, pt 43→47, ara 21→27, gr 40→42).

Screenshot sweep of all 20 captured on the Go 2 — every script renders, no tofu: Arabic and Hebrew via DejaVu, Devanagari and Thai via Noto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)