### PR TITLE
Stop labels resizing the keyboard, and read the locale live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ proofreader for Arabic, Hebrew, Devanagari and Thai. Corrections very welcome.
   🌐 can only reach layouts KDE has been told about, and with one configured it has
   nowhere to go. Reports which have labels and which don't.
 
+  Four layouts can be live at once, and the tool enforces that. An XKB keymap holds
+  four groups — ask libxkbcommon for a fifth and it is discarded outright
+  (`[XKB-595] Unrecognized RMLVO layout "es" was ignored`), so a longer list silently
+  becomes its first four and the rest never appear. Twenty sets of labels ship; which
+  four are live is a `set` plus a log out.
+
   It also shows which layouts KWin is *actually* running with, and offers to log you
   out. That distinction matters more than it sounds: KWin builds its xkb keymap when the
   session starts and there is no way to make it re-read the list — neither
@@ -99,6 +105,24 @@ proofreader for Arabic, Hebrew, Devanagari and Thai. Corrections very welcome.
   and tone marks on `5`–`9` — which costs you the digits and still cannot produce every
   syllable. Most Vietnamese typing uses an IME (Telex/VNI) over a US layout. That works
   here; the layout is shipped for those who want it.
+
+### Fixed since rc5
+
+- **A label can no longer resize the keyboard.** The key grid is column-homogeneous, so
+  every column is as wide as the widest cell — and the 🌐 key reading `🌐LATAM` inflated
+  all thirty-six of them, pushing the window to 1728px on a 1280px desktop. GTK refuses
+  to shrink a window below its natural width, so ⤓ re-docked to 1280, was refused, and
+  looked broken. Labels (and predicted words, which had the same power) now ellipsize;
+  the window's size is the dock's business alone.
+- **The 🌐 badge names what the OS is actually typing.** The layout list was read from
+  `kxkbrc` and the index from the live session — but the file is what the *next* session
+  loads. Edit it and `list[index]` names some other layout: the keyboard drew Brazilian
+  labels while the OS typed US. Both halves now come from the live session.
+- **"Keyboard languages…" in the tray.** A kdialog checklist of all twenty languages —
+  tick up to four, get offered the logout. Configuring the keyboard by typing commands
+  was exactly backwards. Also `handheld-kbd-locales --gui`.
+- **The four-layout ceiling is enforced and explained**, rather than silently truncated
+  by libxkbcommon.
 
 ## v1.0.10 — The Steam Deck keeps its trackpads
 

--- a/README.md
+++ b/README.md
@@ -163,12 +163,16 @@ with `"prediction": false`.
 
 ```bash
 handheld-kbd-locales                # what's configured, and what labels exist
-handheld-kbd-locales add it vn      # Italian and Vietnamese
-handheld-kbd-locales set us ru      # replace the list
+handheld-kbd-locales set us gb it ru
 ```
 
 Then log out and back in — KDE reads its layout list at session start — and 🌐 cycles
 through them.
+
+**Four at a time.** Labels ship for twenty layouts, but an XKB keymap holds four groups
+at most, so four can be live at once. That is the keymap format, not a setting: ask
+libxkbcommon for a fifth and it discards it outright (`Unrecognized RMLVO layout "es" was
+ignored`). Swapping which four is a `set` plus a log out.
 
 Worth knowing how this works, because it explains what it can and can't do. The keyboard
 injects real keycodes, exactly like a USB keyboard; **what a key types is decided by the

--- a/bin/handheld-kbd-locales
+++ b/bin/handheld-kbd-locales
@@ -28,6 +28,16 @@ import sys
 
 CFG_DIR = os.path.expanduser("~/.config/handheld-kbd")
 SHIPPED = os.path.join(CFG_DIR, "locales")
+
+# An XKB keymap holds at most four groups. This is not a KDE setting or a limit of this
+# program: ask libxkbcommon for five layouts and it discards the fifth outright —
+#
+#   xkbcommon: ERROR: [XKB-595] Unrecognized RMLVO layout "es" was ignored
+#
+# so a longer list silently becomes its first four, and 🌐 cycles those. Labels are
+# shipped for twenty layouts; four of them are live at a time, and which four is a
+# config change plus a log out.
+MAX_LAYOUTS = 4
 BOLD, DIM, GREEN, YELLOW, RESET = "\033[1m", "\033[2m", "\033[32m", "\033[33m", "\033[0m"
 
 
@@ -102,7 +112,8 @@ def show():
     if len(have) < 2:
         print(f"\n  {YELLOW}Only one layout: 🌐 has nowhere to switch to.{RESET}"
               f" Add one with 'handheld-kbd-locales add <code>'.")
-    print(f"\n{BOLD}Labels available{RESET}")
+    print(f"\n{BOLD}Labels available{RESET}"
+          f"  {DIM}(four can be live at once — an XKB keymap holds four groups){RESET}")
     for code, name in sorted(avail.items()):
         here = "•" if code in have else " "
         print(f"  {here} {code:6s} {name}")
@@ -112,8 +123,14 @@ def show():
 
 def apply(codes, verb):
     avail = available()
+    dropped = codes[MAX_LAYOUTS:]
+    codes = codes[:MAX_LAYOUTS]
     unknown = [c for c in codes if c not in avail]
     write_layouts(codes)
+    if dropped:
+        print(f"{YELLOW}!!{RESET} An XKB keymap holds four groups at most, so"
+              f" {', '.join(dropped)} {'were' if len(dropped) > 1 else 'was'} left out."
+              f"\n   Choose a different four with 'handheld-kbd-locales set <codes>'.")
     print(f"{GREEN}::{RESET} {verb}: {', '.join(codes) if codes else '(empty)'}")
     if unknown:
         print(f"{YELLOW}!!{RESET} no key labels for: {', '.join(unknown)} — they will type"
@@ -130,11 +147,47 @@ def apply(codes, verb):
         pass
 
 
+def gui():
+    """A touch-friendly picker: tick up to four languages, get offered the logout.
+
+    This exists because the CLI is exactly the wrong tool on a handheld — the thing being
+    configured is the keyboard, and kdialog is present on every KDE image.
+    """
+    avail, have = available(), configured()
+    args = ["kdialog", "--title", "Keyboard languages",
+            "--checklist", "Pick up to four — an XKB keymap holds four groups.\n"
+            "New picks need a log out to take effect."]
+    for code, name in sorted(avail.items()):
+        args += [code, f"{name} ({code})", "on" if code in have else "off"]
+    try:
+        out = subprocess.run(args, capture_output=True, text=True, timeout=600)
+    except FileNotFoundError:
+        print("kdialog not found — use the CLI: handheld-kbd-locales set <codes>",
+              file=sys.stderr)
+        return 1
+    if out.returncode != 0:          # cancelled
+        return 0
+    picked = [c.strip('"') for c in out.stdout.split() if c.strip('"')]
+    if not picked:
+        subprocess.run(["kdialog", "--sorry",
+                        "Nothing selected — keeping the current languages."], timeout=60)
+        return 0
+    if len(picked) > MAX_LAYOUTS:
+        subprocess.run(["kdialog", "--sorry",
+                        f"That was {len(picked)} — an XKB keymap holds four groups.\n"
+                        f"Keeping the first four: {', '.join(picked[:MAX_LAYOUTS])}"],
+                       timeout=60)
+    apply(picked, "layouts set to")
+    return 0
+
+
 def main():
     argv = sys.argv[1:]
     if not argv or argv[0] in ("list", "show", "-l"):
         show()
         return 0
+    if argv[0] == "--gui":
+        return gui()
     cmd, codes = argv[0], [c.strip().lower() for c in argv[1:] if c.strip()]
     if cmd in ("-h", "--help", "help"):
         print(__doc__)
@@ -152,6 +205,13 @@ def main():
         if new == have:
             print(f"{DIM}already configured: {', '.join(codes)}{RESET}")
             return 0
+        if len(new) > MAX_LAYOUTS:
+            print(f"{YELLOW}!!{RESET} That would be {len(new)} layouts, and an XKB keymap"
+                  f" holds four.\n   You have: {', '.join(have)}"
+                  f"\n   Replace them outright with:"
+                  f" handheld-kbd-locales set {' '.join((have + codes)[:MAX_LAYOUTS])}",
+                  file=sys.stderr)
+            return 1
         apply(new, "layouts")
     elif cmd in ("remove", "rm"):
         new = [c for c in have if c not in codes]

--- a/bin/handheld-kbd-tray
+++ b/bin/handheld-kbd-tray
@@ -11,6 +11,7 @@ package, so a dependency here is a dependency that cannot be installed.
 
     handheld-kbd-tray            run it (normally started by autostart)
 """
+import fcntl
 import os
 import signal
 import subprocess
@@ -130,13 +131,15 @@ def kbd_shown():
 class Tray:
     # id: (label, icon, action). 0 is the root, which dbusmenu reserves.
     ACTIONS = {
-        1: ("Show keyboard",         "input-keyboard",  lambda: run(f"{BIN}/handheld-kbd-toggle")),
-        3: ("Restart keyboard",      "view-refresh",    lambda: run(f"{BIN}/handheld-kbd-ctl", "restart")),
-        4: ("Reset position",        "go-bottom",       lambda: run(f"{BIN}/handheld-kbd-ctl", "reset")),
-        5: ("Fix trackpad pointer",  "input-touchpad",  lambda: run(f"{BIN}/handheld-kbd-fix-pointer")),
-        7: ("Stop keyboard",         "process-stop",    lambda: run(f"{BIN}/handheld-kbd-ctl", "stop")),
+        1: ("Show keyboard",         "input-keyboard",         lambda: run(f"{BIN}/handheld-kbd-toggle")),
+        3: ("Restart keyboard",      "view-refresh",           lambda: run(f"{BIN}/handheld-kbd-ctl", "restart")),
+        4: ("Reset position",        "go-bottom",              lambda: run(f"{BIN}/handheld-kbd-ctl", "reset")),
+        5: ("Keyboard languages…",   "preferences-desktop-locale",
+                                                               lambda: run(f"{BIN}/handheld-kbd-locales", "--gui")),
+        6: ("Fix trackpad pointer",  "input-touchpad",         lambda: run(f"{BIN}/handheld-kbd-fix-pointer")),
+        8: ("Stop keyboard",         "process-stop",           lambda: run(f"{BIN}/handheld-kbd-ctl", "stop")),
     }
-    SEPARATORS = (2, 6)
+    SEPARATORS = (2, 7)
 
     def __init__(self):
         self.bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
@@ -150,7 +153,7 @@ class Tray:
             # One entry, not two: "Hide" on a hidden keyboard is a dead option, and a
             # tray menu is read at a glance.
             return "Hide keyboard" if kbd_shown() else "Show keyboard"
-        if item_id == 7 and not kbd_running():
+        if item_id == 8 and not kbd_running():
             return "Start keyboard"
         return text
 
@@ -262,7 +265,21 @@ class Tray:
             return True          # try again on the next tick
 
 
+def single_instance():
+    """Two trays means two identical icons in the panel, which looks like a bug because
+    it is one. Autostart and the supervisor both launch this, deliberately — either alone
+    would leave gaps — so they race at login and a pgrep check loses that race. A lock
+    held for the process's lifetime cannot."""
+    fd = open("/tmp/handheld-kbd-tray.lock", "w")
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        sys.exit(0)
+    return fd                       # returned so it stays open, and the lock held
+
+
 def main():
+    _lock = single_instance()       # noqa: F841
     tray = Tray()
 
     def on_acquired(conn, name, _user=None):

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -13,7 +13,7 @@ If any JSON is missing/invalid, built-in defaults are used so it always comes up
 """
 import gi, sys, time, os, signal, json, subprocess, math, re
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, Gdk, GLib
+from gi.repository import Gtk, Gdk, GLib, Pango
 from evdev import UInput, ecodes as e
 GLib.set_prgname("handheld-kbd")   # app_id so the KWin window-rule can match us
 
@@ -157,16 +157,35 @@ def load_locale_map(code):
 
 
 def active_layout_code():
-    """The XKB layout code (e.g. 'us'/'gb') KDE currently has active."""
+    """The XKB layout code (e.g. 'us'/'gb') KDE currently has active.
+
+    Both the list and the index must come from the LIVE session. This used to read the
+    list from kxkbrc and only the index from DBus — but kxkbrc is what the *next* session
+    will load, not what this one is running: KWin builds its keymap at login and never
+    re-reads the file. Edit the file (handheld-kbd-locales does) and the two go different
+    lengths and orders, so list[index] names some other layout entirely — the keyboard
+    drew Brazilian labels while the OS typed US.
+    """
+    try:
+        out = subprocess.check_output(
+            ["busctl", "--user", "call", "org.kde.keyboard", "/Layouts",
+             "org.kde.KeyboardLayouts", "getLayoutsList"], text=True, timeout=3)
+        # a(sss): triplets of (code, variant, display name), every string quoted.
+        codes = out.split('"')[1::2][0::3]
+        idx = int(subprocess.check_output(
+            ["qdbus6", "org.kde.keyboard", "/Layouts", "org.kde.KeyboardLayouts.getLayout"],
+            text=True, timeout=3).strip())
+        if codes:
+            return codes[idx] if 0 <= idx < len(codes) else codes[0]
+    except Exception:
+        pass
+    # No live answer (e.g. kded still starting): fall back to the config file.
     try:
         ll = subprocess.check_output(
             ["kreadconfig6", "--file", "kxkbrc", "--group", "Layout", "--key", "LayoutList"],
             text=True, timeout=3).strip()
         codes = [c.strip() for c in ll.split(",") if c.strip()]
-        idx = int(subprocess.check_output(
-            ["qdbus6", "org.kde.keyboard", "/Layouts", "org.kde.KeyboardLayouts.getLayout"],
-            text=True, timeout=3).strip())
-        return codes[idx] if 0 <= idx < len(codes) else (codes[0] if codes else "us")
+        return codes[0] if codes else "us"
     except Exception:
         return "us"
 
@@ -279,6 +298,16 @@ class OSK(Gtk.Window):
             for (label, kc, kind, shifted, name) in row:
                 sp = SPAN.get(kind, 2)
                 b = Gtk.Button(label=label)
+                # A label must never dictate the window's size. The grid is
+                # column-homogeneous, so ONE wide label widens every column — the 🌐 key
+                # reading "🌐LATAM" pushed the whole keyboard to 1728px on a 1280px
+                # desktop, and since GTK refuses to shrink a window below its natural
+                # width, ⤓ could no longer bring it back either. Ellipsizing makes the
+                # natural width tiny; the homogeneous grid still gives every key its
+                # even share of whatever width the dock grants.
+                ch = b.get_child()
+                if isinstance(ch, Gtk.Label):
+                    ch.set_ellipsize(Pango.EllipsizeMode.END)
                 b.set_can_focus(False)
                 b.set_hexpand(True); b.set_vexpand(False)
                 b.set_size_request(-1, kh)
@@ -421,6 +450,10 @@ class OSK(Gtk.Window):
         bar.set_size_request(-1, int(self.cfg.get("suggest_height", 44)))
         for i in range(n):
             b = Gtk.Button(label="")
+            # Same rule as the keys: a long suggested word must not widen the window.
+            ch = b.get_child()
+            if isinstance(ch, Gtk.Label):
+                ch.set_ellipsize(Pango.EllipsizeMode.END)
             b.set_can_focus(False)
             b.set_hexpand(True)
             b.get_style_context().add_class("suggest")

--- a/tools/typing-test.py
+++ b/tools/typing-test.py
@@ -26,6 +26,8 @@ import time
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib      # noqa: E402
+
+GLib.set_prgname("handheld-kbd-typing-test")   # so KWin can find the window to focus
 from evdev import UInput, ecodes as e    # noqa: E402
 
 LOCALES = os.path.expanduser("~/.config/handheld-kbd/locales")
@@ -114,6 +116,30 @@ def switch_to(code):
     return current()
 
 
+APP_ID = "handheld-kbd-typing-test"
+
+
+def kwin_activate():
+    """Give the sink keyboard focus.
+
+    A Wayland client cannot focus itself, and a keystroke goes to whatever the compositor
+    thinks is active — so without this the test types into someone else's window and reads
+    back an empty entry, which looks exactly like every layout being broken.
+    """
+    js = "/tmp/handheld-kbd-typing-activate.js"
+    with open(js, "w") as f:
+        f.write(
+            'workspace.windowList().forEach(function(w){'
+            f'  if (("" + w.resourceClass).indexOf("{APP_ID}") !== -1)'
+            '     workspace.activeWindow = w;'
+            '});')
+    for args in (["unloadScript", "hk-activate"], ["loadScript", js, "hk-activate"],
+                 ["start"]):
+        subprocess.run(["qdbus6", "org.kde.KWin", "/Scripting",
+                        "org.kde.kwin.Scripting." + args[0]] + args[1:],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+
+
 class Sink(Gtk.Window):
     """A focused text entry, which is the only honest way to ask what arrived."""
 
@@ -125,6 +151,17 @@ class Sink(Gtk.Window):
         self.set_keep_above(True)
         self.show_all()
         self.entry.grab_focus()
+        self.present()
+
+    def take_focus(self, timeout=5.0):
+        end = time.time() + timeout
+        while time.time() < end:
+            if self.has_toplevel_focus():
+                return True
+            self.present()
+            kwin_activate()
+            pump(0.5)
+        return self.has_toplevel_focus()
 
     def typed(self):
         return self.entry.get_text()
@@ -154,6 +191,8 @@ def run_one(code, ui, sink, settle):
     unmapped = sorted({c for c in sentence if c not in cmap})
     typeable = "".join(c for c in sentence if c in cmap)
 
+    if not sink.take_focus():
+        return code, None, "the sink window could not take keyboard focus", []
     sink.clear()
     pump(0.4)
     for ch in typeable:
@@ -173,12 +212,19 @@ def run_one(code, ui, sink, settle):
 
 def main():
     wanted = [c for c in sys.argv[1:] if c in SENTENCES] or list(SENTENCES)
-    ui = UInput({e.EV_KEY: sorted({getattr(e, n) for n in dir(e)
-                                   if n.startswith("KEY_")
-                                   and isinstance(getattr(e, n), int)})},
-                name="handheld-kbd-typing-test")
+
+    # Only the keys these layouts actually use. Enabling every KEY_* name evdev exposes
+    # fails outright — the module also defines KEY_MAX and KEY_CNT, which are counts
+    # rather than keys, and the kernel rejects the whole device because of them.
+    keys = {e.KEY_LEFTSHIFT, e.KEY_RIGHTALT, e.KEY_SPACE}
+    for code in wanted:
+        cmap, err = char_map(code)
+        if cmap:
+            keys |= {kc for kc, _ in cmap.values()}
+    ui = UInput({e.EV_KEY: sorted(keys)}, name="handheld-kbd-typing-test")
     sink = Sink()
     pump(1.0)
+    sink.take_focus()
 
     failures = 0
     for code in wanted:


### PR DESCRIPTION
Three bugs surfaced together when all twenty languages went onto a Legion Go 2, plus typing-test hardening.

## A label could resize the keyboard

The grid is column-homogeneous: every column as wide as the widest cell. The 🌐 key reading `🌐LATAM` inflated all 36 columns → **1728px window on a 1280px desktop**, hanging 448px off-screen. And GTK refuses to shrink a window below natural width, so ⤓ re-docked to 1280, was refused by the client, and looked broken — "can't reset the position".

Labels now ellipsize (predicted words too — a long suggestion had the same power). Window size is the dock's business alone. Verified on the device: 1728×440 → **1280×336, bottom-docked**.

## The 🌐 badge lied

Reported as "keyboard says BR but KDE says US" — literally true. The layout *list* came from `kxkbrc`, the *index* from the live session. But the file is what the **next** session loads; edit it and `list[index]` names some other layout. Both now come from the live session's `getLayoutsList`.

## Language management that matches the device

- Tray → **"Keyboard languages…"**: kdialog checklist of all twenty, tick up to four, logout offered. Configuring a keyboard by typing commands was exactly backwards.
- `handheld-kbd-locales --gui` for the same thing; the CLI enforces and explains the four-group XKB ceiling instead of letting libxkbcommon truncate silently.

## Typing-test hardening

- Sink window gets focused via KWin — a Wayland client can't focus itself, and an unfocused sink reads back empty, which looks exactly like every layout failing.
- uinput device built from only the keys the layouts use — `KEY_MAX`/`KEY_CNT` are counts, not keys, and enabling them makes the kernel reject the whole device.
- Capitals: locale files omit `shifted` when it's just the uppercase, so the mapper synthesises Shift+key or every capital reads untypeable.

End-to-end results so far on the Go 2: **us, gb, de, fr, es, latam all pass** (es/latam with `é í ú` flagged as needing dead-key composition, as designed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)