### PR TITLE
Prove all twenty languages in Kate; warn about Latin shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,24 @@ proofreader for Arabic, Hebrew, Devanagari and Thai. Corrections very welcome.
   syllable. Most Vietnamese typing uses an IME (Telex/VNI) over a US layout. That works
   here; the layout is shipped for those who want it.
 
+### Verified
+
+Every one of the twenty languages typed into Kate through `/dev/uinput`, saved with
+Ctrl+S, and the file read back off disk and compared character by character. Key
+positions come from the locale files this keyboard ships, so a label on the wrong key
+fails the test — in scripts nobody here can proofread. `tools/kate-type.py`.
+
+All twenty pass. Spanish, Greek and Vietnamese type everything except the characters
+needing dead-key or combining composition, as expected.
+
+### Known: keep one Latin layout among your four
+
+Application shortcuts are bound to Latin keysyms. With only non-Latin layouts loaded the
+S key produces `Cyrillic_yeru`, and Ctrl+S never reaches Save — Ctrl+C and Ctrl+V go the
+same way. KDE's Latin fallback covers global shortcuts, not an application's own. Found
+by this test failing every save under `ru ua gr ara`, and passing the moment `us` was in
+the group. `handheld-kbd-locales` now warns when a selection has no Latin layout.
+
 ### Fixed since rc5
 
 - **A label can no longer resize the keyboard.** The key grid is column-homogeneous, so

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ handheld-kbd-locales set us gb it ru
 Then log out and back in — KDE reads its layout list at session start — and 🌐 cycles
 through them.
 
+**Keep one Latin layout among your four.** Application shortcuts are bound to Latin
+keysyms, so with only non-Latin layouts loaded the S key produces (say) `Cyrillic_yeru`
+and `Ctrl+S` never reaches Save — likewise `Ctrl+C`, `Ctrl+V`. KDE's Latin fallback
+covers global shortcuts, not an application's own. `handheld-kbd-locales` warns if you
+pick four without one.
+
 **Four at a time.** Labels ship for twenty layouts, but an XKB keymap holds four groups
 at most, so four can be live at once. That is the keymap format, not a setting: ask
 libxkbcommon for a fifth and it discards it outright (`Unrecognized RMLVO layout "es" was

--- a/bin/handheld-kbd-locales
+++ b/bin/handheld-kbd-locales
@@ -38,6 +38,13 @@ SHIPPED = os.path.join(CFG_DIR, "locales")
 # shipped for twenty layouts; four of them are live at a time, and which four is a
 # config change plus a log out.
 MAX_LAYOUTS = 4
+
+# Layouts whose letters are Latin. At least one wants to be among your four: application
+# shortcuts are bound to Latin keysyms, so under a Cyrillic-only keymap the S key
+# produces Cyrillic_yeru and Ctrl+S never reaches Save. KDE's Latin fallback covers
+# global shortcuts, not an application's own. Verified in Kate on a Legion Go 2 — with
+# only ru/ua/gr/ara loaded, every save silently did nothing.
+LATIN = {"us", "gb", "de", "fr", "es", "latam", "it", "pt", "br", "nl", "pl", "tr", "vn"}
 BOLD, DIM, GREEN, YELLOW, RESET = "\033[1m", "\033[2m", "\033[32m", "\033[33m", "\033[0m"
 
 
@@ -127,6 +134,10 @@ def apply(codes, verb):
     codes = codes[:MAX_LAYOUTS]
     unknown = [c for c in codes if c not in avail]
     write_layouts(codes)
+    if not any(c in LATIN for c in codes):
+        print(f"{YELLOW}!!{RESET} None of these use the Latin alphabet. Application"
+              f" shortcuts are bound to Latin keys,\n   so Ctrl+S, Ctrl+C and the rest"
+              f" will stop working — keep one of us/gb/de/… among the four.")
     if dropped:
         print(f"{YELLOW}!!{RESET} An XKB keymap holds four groups at most, so"
               f" {', '.join(dropped)} {'were' if len(dropped) > 1 else 'was'} left out."

--- a/tools/kate-type.py
+++ b/tools/kate-type.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Prove a language end to end by typing its pangram into Kate.
+
+For each layout code given: switch the OS layout, open Kate on a fresh file, focus it,
+type the sentence through /dev/uinput using the key positions from the keyboard's own
+locale data, press Ctrl+S, and read the saved file back. A real editor, a real save, a
+real file on disk — nothing about this can be faked by the test itself. A screenshot is
+taken while the text is on screen.
+
+Usage: kate-type.py <code> [<code>…]
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+from evdev import UInput, ecodes as e
+
+LOCALES = os.path.expanduser("~/.config/handheld-kbd/locales")
+OUTDIR = "/tmp/kate-proof"
+LEVELS = (("label", []), ("shifted", [e.KEY_LEFTSHIFT]), ("alt", [e.KEY_RIGHTALT]))
+
+SENTENCES = {
+    "us":    "The quick brown fox jumps over the lazy dog",
+    "gb":    "The quick brown fox jumps over the lazy dog",
+    "de":    "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich",
+    "fr":    "Portez ce vieux whisky au juge blond qui fume",
+    "es":    "El veloz murciélago hindú comía feliz cardillo y kiwi",
+    "latam": "El veloz murciélago hindú comía feliz cardillo y kiwi",
+    "it":    "Ma la volpe col suo balzo ha raggiunto il quieto Fido",
+    "pt":    "Um pequeno jabuti xereta viu dez cegonhas felizes",
+    "br":    "Um pequeno jabuti xereta viu dez cegonhas felizes",
+    "nl":    "Pa's wijze lynx bezag vroom het fikse aquaduct",
+    "pl":    "Pchnąć w tę łódź jeża lub ośm skrzyń fig",
+    "tr":    "Pijamalı hasta yağız şoföre çabucak güvendi",
+    "ru":    "Съешь же ещё этих мягких французских булок да выпей чаю",
+    "ua":    "Чуєш їх доцю га кумедна ж ти",
+    "gr":    "Ξεσκεπάζω την ψυχοφθόρα βδελυγμία",
+    "ara":   "نص حكيم له سر قاطع وذو شأن عظيم",
+    "il":    "דג סקרן שט בים מאוכזב ולפתע מצא חברה",
+    "in":    "ऋषि को क्षमा चाहिए",
+    "th":    "เป็นมนุษย์สุดประเสริฐเลิศคุณค่า",
+    "vn":    "Do bạch kim rất quý nên sẽ dùng để lắp vô xe",
+}
+
+
+def char_map(code):
+    with open(os.path.join(LOCALES, f"{code}.json")) as f:
+        data = json.load(f)
+    out = {}
+    for key_name, entry in data.items():
+        kc = getattr(e, key_name, None)
+        if not isinstance(kc, int):
+            continue
+        for field, mods in LEVELS:
+            ch = entry.get(field)
+            if ch and len(ch) == 1:
+                out.setdefault(ch, (kc, mods))
+        label = entry.get("label")
+        if label and len(label) == 1 and "shifted" not in entry:
+            upper = label.upper()
+            if len(upper) == 1 and upper != label:
+                out.setdefault(upper, (kc, [e.KEY_LEFTSHIFT]))
+    out.setdefault(" ", (e.KEY_SPACE, []))
+    return out
+
+
+def kwin_run(js, name):
+    path = f"/tmp/{name}.js"
+    with open(path, "w") as f:
+        f.write(js)
+    for args in (["unloadScript", name], ["loadScript", path, name], ["start"]):
+        subprocess.run(["qdbus6", "org.kde.KWin", "/Scripting",
+                        "org.kde.kwin.Scripting." + args[0]] + args[1:],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+
+
+def focus_kate():
+    kwin_run('workspace.windowList().forEach(function(w){'
+             ' if (("" + w.resourceClass).indexOf("kate") !== -1)'
+             '   workspace.activeWindow = w; });', "hk-kate-focus")
+
+
+def kate_present():
+    r = subprocess.run(["pgrep", "-f", "/usr/bin/kate|bin/kate"],
+                       stdout=subprocess.DEVNULL)
+    return r.returncode == 0
+
+
+def switch_to(code):
+    def current():
+        try:
+            out = subprocess.check_output(
+                ["busctl", "--user", "call", "org.kde.keyboard", "/Layouts",
+                 "org.kde.KeyboardLayouts", "getLayoutsList"], text=True, timeout=5)
+            codes = out.split('"')[1::2][0::3]
+            idx = int(subprocess.check_output(
+                ["qdbus6", "org.kde.keyboard", "/Layouts",
+                 "org.kde.KeyboardLayouts.getLayout"], text=True, timeout=5).strip())
+            return codes[idx] if 0 <= idx < len(codes) else None
+        except Exception:
+            return None
+    for _ in range(20):
+        if current() == code:
+            return True
+        subprocess.run(["qdbus6", "org.kde.keyboard", "/Layouts",
+                        "org.kde.KeyboardLayouts.switchToNextLayout"],
+                       stdout=subprocess.DEVNULL, timeout=5)
+        time.sleep(0.3)
+    return current() == code
+
+
+def press(ui, kc, mods=()):
+    for m in mods:
+        ui.write(e.EV_KEY, m, 1)
+    ui.syn()
+    ui.write(e.EV_KEY, kc, 1); ui.syn()
+    ui.write(e.EV_KEY, kc, 0); ui.syn()
+    for m in reversed(mods):
+        ui.write(e.EV_KEY, m, 0)
+    ui.syn()
+    time.sleep(0.015)
+
+
+def run_one(code, ui):
+    sentence = SENTENCES[code]
+    try:
+        cmap = char_map(code)
+    except Exception as ex:
+        return f"SKIP  no locale data ({ex})"
+    if not switch_to(code):
+        return "SKIP  KDE would not switch to this layout"
+
+    path = f"{OUTDIR}/{code}.txt"
+    if os.path.exists(path):
+        os.remove(path)
+    kate = subprocess.Popen(["kate", "-n", "--startanon", path],
+                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    for _ in range(30):                       # wait for the window, then focus it
+        time.sleep(0.5)
+        focus_kate()
+        if kate_present():
+            break
+    time.sleep(2.0)
+    focus_kate()
+    time.sleep(1.0)
+
+    typeable = "".join(c for c in sentence if c in cmap)
+    skipped = sorted({c for c in sentence if c not in cmap})
+    for ch in typeable:
+        kc, mods = cmap[ch]
+        press(ui, kc, mods)
+    time.sleep(0.5)
+    press(ui, e.KEY_S, [e.KEY_LEFTCTRL])      # a real save, through the same device
+    time.sleep(2.0)
+
+    shot = f"{OUTDIR}/{code}.png"
+    subprocess.run(["spectacle", "-b", "-n", "-f", "-o", shot],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30)
+
+    kate.terminate()
+    try:
+        kate.wait(timeout=5)
+    except Exception:
+        kate.kill()
+    time.sleep(0.5)
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            got = f.read().rstrip("\n")
+    except Exception:
+        return "FAIL  Kate saved nothing"
+    note = f"   [needs composing: {''.join(skipped)}]" if skipped else ""
+    if got == typeable:
+        return f"ok    {len(typeable)} chars into Kate and back{note}"
+    return (f"FAIL  file differs{note}\n"
+            f"         expected {typeable!r}\n"
+            f"         got      {got!r}")
+
+
+def main():
+    os.makedirs(OUTDIR, exist_ok=True)
+    codes = [c for c in sys.argv[1:] if c in SENTENCES]
+    keys = {e.KEY_LEFTSHIFT, e.KEY_RIGHTALT, e.KEY_LEFTCTRL, e.KEY_S, e.KEY_SPACE}
+    for code in codes:
+        try:
+            keys |= {kc for kc, _ in char_map(code).values()}
+        except Exception:
+            pass
+    ui = UInput({e.EV_KEY: sorted(keys)}, name="handheld-kbd-kate-test")
+    time.sleep(1.0)
+    fails = 0
+    for code in codes:
+        result = run_one(code, ui)
+        fails += result.startswith("FAIL")
+        print(f"  {code:6s} {result}")
+        sys.stdout.flush()
+    ui.close()
+    print(f"\n{len(codes)} languages, {fails} failed")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Every language typed into a real editor through `/dev/uinput`, saved with Ctrl+S, file read back off disk and compared character by character. Key positions come from the locale files we ship — so a label on the wrong key fails the test, which is the whole point in scripts nobody here can proofread.

**All twenty pass on a Legion Go 2.**

```
us gb de fr    ok        br nl pl tr    ok
es latam       ok  [éíú] il in th       ok
it pt          ok        vn             ok  [ùýạấắẽể]
ru ua ara      ok        gr             ok  [άίό]
```

Bracketed characters need dead-key or combining composition — reported as such, not counted as failures.

## The test found a real constraint

Under `ru ua gr ara` every save silently did nothing. Not a harness bug: **application shortcuts are bound to Latin keysyms**, so with no Latin group loaded the S key produces `Cyrillic_yeru` and `Ctrl+S` never reaches Save. `Ctrl+C`, `Ctrl+V` go the same way. KDE's Latin fallback covers *global* shortcuts, not an application's own.

Adding `us` to the group made all four pass unchanged.

Since only four layouts can be live at once, this is a choice a user can get wrong, so `handheld-kbd-locales` warns when a selection has no Latin layout, and the README says to keep one.

## Harness notes

Three things had to be right before any of this measured anything real: the sink window needs KWin to focus it (a Wayland client can't focus itself, and an unfocused sink reads back empty — indistinguishable from total failure); the uinput device must enable only the keys in use (`KEY_MAX`/`KEY_CNT` are counts, and including them makes the kernel reject the device); and capitals need synthesising, since locale files omit `shifted` when it's just the uppercase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)