### PR TITLE
Ask for the password while you still have a keyboard; name languages properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,30 @@ same way. KDE's Latin fallback covers global shortcuts, not an application's own
 by this test failing every save under `ru ua gr ara`, and passing the moment `us` was in
 the group. `handheld-kbd-locales` now warns when a selection has no Latin layout.
 
+### Fixed since rc8
+
+- **Upgrading no longer asks for a password you cannot type.** The privileged step —
+  the udev rule and `input` group that let the keyboard reach `/dev/uinput` — ran last,
+  so on a handheld the prompt could arrive after the keyboard it was replacing had gone,
+  with nothing to answer it with. It now runs first, while whatever keyboard you started
+  with is still alive. On an upgrade it does not run at all: the rule and the group are
+  already there, and the installer says so instead of asking.
+- **The 🌐 key names the language, not the country.** It showed the xkb code, and `il`
+  is Israel rather than Hebrew, `in` is India rather than Hindi, `latam` did not fit, and
+  `us` and `gb` are both English. Latin layouts keep the familiar two letters; the rest
+  get their own script — `עב`, `ع`, `हि`, `ไทย`, `РУ`, `УК`, `ΕΛ`.
+- **The logout prompt notices a swap.** It compared how many layouts were configured
+  against how many were running, so exchanging Russian for Vietnamese — four for four,
+  and the most likely change anyone makes — looked like nothing had happened. It compares
+  the two sets now.
+- **The language picker shows what is in rotation** before you change it, states the
+  four-at-a-time rule up front, and confirms rather than silently truncating when you
+  tick more, tick none, or tick four without a Latin layout among them.
+- **Currency symbols are part of the language test.** Most layouts keep theirs on the
+  third level — `€` on AltGr-E, `₺`, `₽`, `₪`, `฿`, `₫`, `₯` — so typing them exercises
+  AltGr and the level-3 labels in the place a user is most likely to notice being wrong.
+  Symbols are taken from each layout's own data rather than assumed.
+
 ### Fixed since rc5
 
 - **A label can no longer resize the keyboard.** The key grid is column-homogeneous, so

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ So I built the keyboard I wanted instead. Here's what it does differently:
 
 ## Install
 
+Upgrading? Just re-run the installer — it won't ask for a password, because the
+permission it needs is already there from last time.
+
 Double-click **`Install Better Handheld Keyboard.desktop`**, enter your password
 once (it needs `/dev/uinput` access — that's how it types real keys), then **log
 out and back in**.

--- a/bin/handheld-kbd-locales
+++ b/bin/handheld-kbd-locales
@@ -53,10 +53,16 @@ BOLD, DIM, GREEN, YELLOW, RED, RESET = ("\033[1m", "\033[2m", "\033[32m",
 
 
 def available():
-    """{code: language name} for the layouts we ship labels for."""
+    """{code: language name} for the layouts we ship labels for.
+
+    The index also carries the 🌐 key badge per language; older installs hold a plain
+    {code: name} map, so accept both rather than breaking on an un-upgraded config.
+    """
     try:
         with open(os.path.join(SHIPPED, "index.json")) as f:
-            return json.load(f)
+            raw = json.load(f)
+        return {c: (v.get("name", c) if isinstance(v, dict) else v)
+                for c, v in raw.items()}
     except Exception:
         return {os.path.splitext(n)[0]: "" for n in sorted(os.listdir(SHIPPED))
                 if n.endswith(".json") and n != "index.json"}
@@ -261,36 +267,63 @@ def apply(codes, verb):
 
 
 def gui():
-    """A touch-friendly picker: tick up to four languages, get offered the logout.
+    """The language picker: what is in rotation now, tick four, log out if needed.
 
-    This exists because the CLI is exactly the wrong tool on a handheld — the thing being
-    configured is the keyboard, and kdialog is present on every KDE image.
+    A checklist rather than a command line, because the thing being configured is the
+    keyboard — needing a keyboard to fix the keyboard is the problem this project exists
+    for. It states the four-at-a-time rule up front rather than letting someone tick
+    eight and wonder why half of them vanished.
     """
-    avail, have = available(), configured()
-    args = ["kdialog", "--title", "Keyboard languages",
-            "--checklist", "Pick up to four — an XKB keymap holds four groups.\n"
-            "New picks need a log out to take effect."]
-    for code, name in sorted(avail.items()):
+    avail, have, now = available(), configured(), live() or []
+    rotation = ", ".join(now) if now else "none"
+    header = (f"In rotation now (the globe key cycles these): {rotation}\n\n"
+              f"Tick up to {MAX_LAYOUTS} — a keyboard layout map holds four at a time.\n"
+              f"Keep one Latin language among them, or Ctrl+S and Ctrl+C stop working.")
+    args = ["kdialog", "--title", "Keyboard languages", "--checklist", header]
+    for code, name in sorted(avail.items(), key=lambda kv: kv[1]):
         args += [code, f"{name} ({code})", "on" if code in have else "off"]
     try:
-        out = subprocess.run(args, capture_output=True, text=True, timeout=600)
+        out = subprocess.run(args, capture_output=True, text=True, timeout=900)
     except FileNotFoundError:
-        print("kdialog not found — use the CLI: handheld-kbd-locales set <codes>",
-              file=sys.stderr)
+        print("kdialog not found — use: handheld-kbd-locales set <codes>", file=sys.stderr)
         return 1
-    if out.returncode != 0:          # cancelled
+    if out.returncode != 0:                      # cancelled
         return 0
+
     picked = [c.strip('"') for c in out.stdout.split() if c.strip('"')]
     if not picked:
-        subprocess.run(["kdialog", "--sorry",
-                        "Nothing selected — keeping the current languages."], timeout=60)
+        subprocess.run(["kdialog", "--title", "Keyboard languages", "--sorry",
+                        "Nothing was ticked, so your languages are unchanged."],
+                       timeout=120)
         return 0
+
     if len(picked) > MAX_LAYOUTS:
-        subprocess.run(["kdialog", "--sorry",
-                        f"That was {len(picked)} — an XKB keymap holds four groups.\n"
-                        f"Keeping the first four: {', '.join(picked[:MAX_LAYOUTS])}"],
-                       timeout=60)
-    apply(picked, "layouts set to")
+        keep = picked[:MAX_LAYOUTS]
+        listed = "\n".join(f"  {c} — {avail.get(c, '')}" for c in keep)
+        r = subprocess.run(["kdialog", "--title", "Keyboard languages",
+                            "--warningcontinuecancel",
+                            f"You ticked {len(picked)}, and only {MAX_LAYOUTS} can be in "
+                            f"rotation.\n\nKeep these four?\n\n{listed}"], timeout=300)
+        if r.returncode != 0:
+            return 0
+        picked = keep
+
+    if not any(c in LATIN for c in picked):
+        r = subprocess.run(["kdialog", "--title", "Keyboard languages",
+                            "--warningcontinuecancel",
+                            "None of these use the Latin alphabet.\n\nApplication "
+                            "shortcuts are bound to Latin keys, so Ctrl+S, Ctrl+C and "
+                            "Ctrl+V will stop working until you add one.\n\n"
+                            "Carry on anyway?"], timeout=300)
+        if r.returncode != 0:
+            return 0
+
+    if sorted(picked) == sorted(have) and sorted(picked) == sorted(now):
+        subprocess.run(["kdialog", "--title", "Keyboard languages", "--msgbox",
+                        "No change — those are already in rotation."], timeout=120)
+        return 0
+
+    apply(picked, "layouts set to")               # this prompts for the logout
     return 0
 
 

--- a/bin/handheld-kbd-relogin
+++ b/bin/handheld-kbd-relogin
@@ -1,31 +1,52 @@
 #!/bin/bash
-# Better Handheld Keyboard — tell the user (and optionally trigger) a logout when keyboard-layout
-# config has been changed but not yet applied. KWin/kded only read kxkbrc at session
-# start, so newly-added layouts (e.g. adding 'gb') don't work until a relogin.
+# Better Handheld Keyboard — notice when the keyboard-layout config no longer matches the
+# running session, and offer to log out.
+#
+# KWin builds its XKB keymap when the session starts and never re-reads it: neither
+# org.kde.KWin.reconfigure nor reloading kded's keyboard module picks up a change. So a
+# layout written to kxkbrc sits there looking configured while 🌐 refuses to reach it.
 #
 #   handheld-kbd-relogin            -> if a relogin is pending, show a desktop notification
-#   handheld-kbd-relogin --prompt   -> if pending, show a Yes/No dialog and log out on Yes
+#   handheld-kbd-relogin --prompt   -> if pending, ask, and log out on Yes
 #   handheld-kbd-relogin --check    -> exit 0 if a relogin is pending, 1 if not (no UI)
 export DISPLAY="${DISPLAY:-:0}"
 
-configured=$(kreadconfig6 --file kxkbrc --group Layout --key LayoutList 2>/dev/null | tr ',' '\n' | grep -c .)
-registered=$(qdbus6 --literal org.kde.keyboard /Layouts org.kde.KeyboardLayouts.getLayoutsList 2>/dev/null | grep -c 'Argument: (sss)')
-configured=${configured:-0}; registered=${registered:-0}
+# Compare the two SETS, not their sizes. Swapping Russian for Vietnamese leaves four
+# layouts configured and four running, so a count comparison says "nothing to do" —
+# and the swap is exactly the change a person is most likely to make.
+configured=$(kreadconfig6 --file kxkbrc --group Layout --key LayoutList 2>/dev/null \
+             | tr ',' '\n' | sed 's/^ *//; s/ *$//' | grep . | sort | tr '\n' ' ')
+running=$(busctl --user call org.kde.keyboard /Layouts \
+            org.kde.KeyboardLayouts getLayoutsList 2>/dev/null \
+          | grep -oE '"[a-z]{2,5}"' | tr -d '"' | sort | tr '\n' ' ')
 
 pending=0
-[ "$configured" -gt "$registered" ] && [ "$registered" -ge 1 ] && pending=1
+# No answer from the session (kded still starting) means we cannot tell — and claiming a
+# logout is needed when it is not is worse than staying quiet.
+if [ -n "$running" ] && [ -n "$configured" ] && [ "$configured" != "$running" ]; then
+    pending=1
+fi
 
 case "${1:-}" in
   --check) [ "$pending" = 1 ] && exit 0 || exit 1 ;;
 esac
 [ "$pending" = 1 ] || exit 0
 
-MSG="New keyboard layout(s) won't work until you log out and back in."
+WANT=$(echo "$configured" | sed 's/ $//; s/ /, /g')
+HAVE=$(echo "$running"    | sed 's/ $//; s/ /, /g')
+MSG="Your keyboard languages have changed.\n\nNow running: $HAVE\nAfter logging back in: $WANT\n\nThe desktop has to restart to load them. Save anything open first — logging out closes your apps."
+
 if [ "${1:-}" = "--prompt" ] && command -v kdialog >/dev/null 2>&1; then
-    if kdialog --title "Better Handheld Keyboard" --yesno "$MSG\n\nLog out now?" \
+    if kdialog --title "Keyboard languages" --warningyesno "$MSG" \
                --yes-label "Log out now" --no-label "Later" 2>/dev/null; then
+        # KDE's own logout: it closes applications properly rather than pulling the
+        # session out from under them. loginctl terminate-session is NOT a substitute —
+        # on a Legion Go 2 it removed the session record and left an orphaned KWin that
+        # SDDM would not replace, i.e. a desktop with no way back.
         qdbus6 org.kde.Shutdown /Shutdown org.kde.Shutdown.logout
     fi
 else
-    notify-send -a "Better Handheld Keyboard" -i input-keyboard "Log out to finish setup" "$MSG" 2>/dev/null
+    notify-send -a "Better Handheld Keyboard" -i input-keyboard \
+        "Log out to finish switching languages" \
+        "Now running $HAVE; $WANT after you log back in." 2>/dev/null
 fi

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -148,6 +148,30 @@ def load_layout(name):
         return dict(DEFAULT_LAYOUT)
 
 
+_locale_index = None
+
+
+def locale_badge(code):
+    """What the 🌐 key shows for a layout.
+
+    Not the xkb code: "il" is Israel rather than Hebrew, "in" is India rather than Hindi,
+    and "us" and "gb" are both English — none of which tells you what you are about to
+    type. The index carries a short badge per language, in its own script where that says
+    more than two Latin letters would.
+    """
+    global _locale_index
+    if _locale_index is None:
+        try:
+            with open(os.path.join(CFG_DIR, "locales", "index.json")) as f:
+                _locale_index = json.load(f)
+        except Exception:
+            _locale_index = {}
+    entry = _locale_index.get(code)
+    if isinstance(entry, dict) and entry.get("badge"):
+        return entry["badge"]
+    return code.upper()
+
+
 def load_locale_map(code):
     try:
         with open(os.path.join(CFG_DIR, "locales", f"{code}.json")) as f:
@@ -728,7 +752,7 @@ class OSK(Gtk.Window):
         self.lmap = load_locale_map(code)
         self._relabel()
         if self.locale_btn:
-            self._set_label(self.locale_btn, "🌐" + code.upper(), "")
+            self._set_label(self.locale_btn, "🌐" + locale_badge(code), "")
 
     def _relabel(self):
         """Paint the keys for the current layout and modifier state.

--- a/config/locales/index.json
+++ b/config/locales/index.json
@@ -1,22 +1,82 @@
 {
-  "ara": "Arabic",
-  "br": "Portuguese (Brazil)",
-  "de": "German",
-  "es": "Spanish",
-  "fr": "French",
-  "gb": "English (UK)",
-  "gr": "Greek",
-  "il": "Hebrew",
-  "in": "Hindi (Devanagari)",
-  "it": "Italian",
-  "latam": "Spanish (Latin America)",
-  "nl": "Dutch",
-  "pl": "Polish",
-  "pt": "Portuguese",
-  "ru": "Russian",
-  "th": "Thai",
-  "tr": "Turkish",
-  "ua": "Ukrainian",
-  "us": "English (US)",
-  "vn": "Vietnamese"
+  "ara": {
+    "badge": "ع",
+    "name": "Arabic"
+  },
+  "br": {
+    "badge": "BR",
+    "name": "Portuguese (Brazil)"
+  },
+  "de": {
+    "badge": "DE",
+    "name": "German"
+  },
+  "es": {
+    "badge": "ES",
+    "name": "Spanish"
+  },
+  "fr": {
+    "badge": "FR",
+    "name": "French"
+  },
+  "gb": {
+    "badge": "UK",
+    "name": "English (UK)"
+  },
+  "gr": {
+    "badge": "ΕΛ",
+    "name": "Greek"
+  },
+  "il": {
+    "badge": "עב",
+    "name": "Hebrew"
+  },
+  "in": {
+    "badge": "हि",
+    "name": "Hindi (Devanagari)"
+  },
+  "it": {
+    "badge": "IT",
+    "name": "Italian"
+  },
+  "latam": {
+    "badge": "LA",
+    "name": "Spanish (Latin America)"
+  },
+  "nl": {
+    "badge": "NL",
+    "name": "Dutch"
+  },
+  "pl": {
+    "badge": "PL",
+    "name": "Polish"
+  },
+  "pt": {
+    "badge": "PT",
+    "name": "Portuguese"
+  },
+  "ru": {
+    "badge": "РУ",
+    "name": "Russian"
+  },
+  "th": {
+    "badge": "ไทย",
+    "name": "Thai"
+  },
+  "tr": {
+    "badge": "TR",
+    "name": "Turkish"
+  },
+  "ua": {
+    "badge": "УК",
+    "name": "Ukrainian"
+  },
+  "us": {
+    "badge": "US",
+    "name": "English (US)"
+  },
+  "vn": {
+    "badge": "VI",
+    "name": "Vietnamese"
+  }
 }

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,45 @@ fi
 
 mkdir -p "$BIN" "$CFG/layouts" "$CFG/locales" "$KWIN/contents/code" "$AUTO"
 
+# --- the one privileged step: let it reach /dev/uinput ---
+# Done FIRST, and only when actually needed.
+#
+# It asks for a password, and on a handheld the only way to type one may be the very
+# keyboard this script is replacing. Running it last meant the prompt could arrive after
+# the keyboard had gone, with no way to answer it. Running it first keeps whatever
+# keyboard you started with alive to type into.
+#
+# On an upgrade none of this is needed: the udev rule and the group membership are
+# already there from last time, so the prompt should never appear at all.
+RULE=/etc/udev/rules.d/60-handheld-kbd.rules
+ensure_privilege() {
+  if [ -f "$RULE" ] && { id -nG | tr ' ' '\n' | grep -qx input || [ -w /dev/uinput ]; }; then
+    PRIV_OK=1
+    say "Keyboard-injection permission already in place — no password needed."
+    return
+  fi
+  say "Setting up keyboard-injection permission (you'll be asked for your password once)…"
+  say "   Doing this first, while you still have a keyboard to type it with."
+  PRIV='
+cat > /etc/udev/rules.d/60-handheld-kbd.rules <<EOF
+KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
+EOF
+getent group input >/dev/null || groupadd input
+usermod -aG input "'"$USER"'"
+udevadm control --reload && udevadm trigger /dev/uinput 2>/dev/null
+'
+  if command -v pkexec >/dev/null 2>&1; then
+    pkexec sh -c "$PRIV" && PRIV_OK=1 || PRIV_OK=0
+  else
+    PRIV_OK=0
+  fi
+  if [ "$PRIV_OK" != 1 ]; then
+    warn "Couldn't get permission. Run this once in a terminal, then re-run the installer:"
+    echo "     sudo sh -c '$PRIV'"
+  fi
+}
+ensure_privilege
+
 # --- programs ---
 install -m755 "$HERE/bin/handheld-kbd.py"        "$BIN/"
 install -m755 "$HERE/bin/handheld-kbd-swap.sh"   "$BIN/"
@@ -262,21 +301,8 @@ if command -v kwriteconfig6 >/dev/null 2>&1; then
   qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1 || true
 fi
 
-# --- the one privileged step: let it reach /dev/uinput (single auth prompt) ---
-say "Setting up keyboard-injection permission (you'll be asked for your password once)…"
-PRIV='
-cat > /etc/udev/rules.d/60-handheld-kbd.rules <<EOF
-KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
-EOF
-getent group input >/dev/null || groupadd input
-usermod -aG input "'"$USER"'"
-udevadm control --reload && udevadm trigger /dev/uinput 2>/dev/null
-'
-if command -v pkexec >/dev/null 2>&1; then
-  pkexec sh -c "$PRIV" && PRIV_OK=1 || PRIV_OK=0
-else
-  warn "pkexec not found — run this once yourself:  sudo sh -c '$PRIV'"; PRIV_OK=0
-fi
+# The privileged step now happens near the top, before anything is touched — see
+# ensure_privilege().
 
 # --- dependency check ---
 MISSING=""
@@ -338,4 +364,7 @@ fi
 
 echo
 say "Rebuild the prediction dictionary any time with: handheld-kbd-build-dict"
-[ "${PRIV_OK:-0}" = 1 ] || warn "Permission step didn't complete — typing won't work until it does."
+if [ "${PRIV_OK:-0}" != 1 ]; then
+  warn "Typing won't work until the permission step completes — see the command above."
+  warn "You still have your old keyboard: 'handheld-kbd-recover' puts Steam's back."
+fi

--- a/tools/build-locales.py
+++ b/tools/build-locales.py
@@ -38,27 +38,32 @@ KEYSYMDEF = ("https://gitlab.freedesktop.org/xorg/proto/xorgproto"
 # Deliberately absent: Chinese, Japanese and Korean. Those are not keyboard layouts but
 # input methods; no mapping of keycodes to characters can produce them, and pretending
 # otherwise with a labelled keyboard would be a lie about what pressing the key does.
+# (xkb code, language name, key badge). The badge is what the 🌐 key shows, so it has to
+# say something on a key the width of a thumb. The xkb code will not do: "il" is Israel
+# not Hebrew, "in" is India not Hindi, "us" and "gb" are both English. Latin layouts keep
+# the familiar two letters; the rest get their own script, which is self-evident to
+# anyone who reads it and a decent hint to anyone who does not.
 LAYOUTS = [
-    ("us",    "English (US)"),
-    ("gb",    "English (UK)"),
-    ("de",    "German"),
-    ("fr",    "French"),
-    ("es",    "Spanish"),
-    ("latam", "Spanish (Latin America)"),
-    ("it",    "Italian"),
-    ("pt",    "Portuguese"),
-    ("br",    "Portuguese (Brazil)"),
-    ("nl",    "Dutch"),
-    ("pl",    "Polish"),
-    ("tr",    "Turkish"),
-    ("ru",    "Russian"),
-    ("ua",    "Ukrainian"),
-    ("gr",    "Greek"),
-    ("ara",   "Arabic"),
-    ("il",    "Hebrew"),
-    ("in",    "Hindi (Devanagari)"),
-    ("th",    "Thai"),
-    ("vn",    "Vietnamese"),
+    ("us",    "English (US)",            "US"),
+    ("gb",    "English (UK)",            "UK"),
+    ("de",    "German",                  "DE"),
+    ("fr",    "French",                  "FR"),
+    ("es",    "Spanish",                 "ES"),
+    ("latam", "Spanish (Latin America)", "LA"),
+    ("it",    "Italian",                 "IT"),
+    ("pt",    "Portuguese",              "PT"),
+    ("br",    "Portuguese (Brazil)",     "BR"),
+    ("nl",    "Dutch",                   "NL"),
+    ("pl",    "Polish",                  "PL"),
+    ("tr",    "Turkish",                 "TR"),
+    ("ru",    "Russian",                 "РУ"),
+    ("ua",    "Ukrainian",               "УК"),
+    ("gr",    "Greek",                   "ΕΛ"),
+    ("ara",   "Arabic",                  "ع"),
+    ("il",    "Hebrew",                  "עב"),
+    ("in",    "Hindi (Devanagari)",      "हि"),
+    ("th",    "Thai",                    "ไทย"),
+    ("vn",    "Vietnamese",              "VI"),
 ]
 
 # XKB's key names for the keys this keyboard actually has. Anything else in a symbol
@@ -323,7 +328,7 @@ def main():
     syms = Symbols(symdir, args.fetch)
     os.makedirs(OUT, exist_ok=True)
     index = {}
-    for code, name in LAYOUTS:
+    for code, name, badge in LAYOUTS:
         data = build(code, syms, table)
         if len(data) < 20:
             print(f"  ! {code}: only {len(data)} keys resolved — not written",
@@ -332,7 +337,7 @@ def main():
         with open(os.path.join(OUT, f"{code}.json"), "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, ensure_ascii=False, sort_keys=True)
             f.write("\n")
-        index[code] = name
+        index[code] = {"name": name, "badge": badge}
         alt = sum(1 for v in data.values() if "alt" in v)
         print(f"  {code:6s} {len(data):3d} keys, {alt:3d} with AltGr  — {name}")
 

--- a/tools/kate-type.py
+++ b/tools/kate-type.py
@@ -11,6 +11,7 @@ Usage: kate-type.py <code> [<code>…]
 """
 import json
 import os
+import unicodedata
 import subprocess
 import sys
 import time
@@ -43,6 +44,20 @@ SENTENCES = {
     "th":    "เป็นมนุษย์สุดประเสริฐเลิศคุณค่า",
     "vn":    "Do bạch kim rất quý nên sẽ dùng để lắp vô xe",
 }
+
+
+def currency_for(cmap):
+    """Every currency symbol this layout can reach, cheapest test of AltGr there is.
+
+    Most layouts keep their currency on the third level — € on AltGr-E, ₺ on AltGr-T —
+    so typing them exercises the AltGr key and the level-3 labels together, in the one
+    place a user is most likely to notice being wrong.
+    """
+    out = []
+    for ch, (kc, mods) in cmap.items():
+        if len(ch) == 1 and unicodedata.category(ch) == "Sc":
+            out.append(ch)
+    return sorted(out)
 
 
 def char_map(code):
@@ -124,11 +139,13 @@ def press(ui, kc, mods=()):
 
 
 def run_one(code, ui):
-    sentence = SENTENCES[code]
     try:
         cmap = char_map(code)
     except Exception as ex:
         return f"SKIP  no locale data ({ex})"
+    # The pangram exercises the alphabet; the currency symbols exercise AltGr.
+    money = currency_for(cmap)
+    sentence = SENTENCES[code] + ((" " + " ".join(money)) if money else "")
     if not switch_to(code):
         return "SKIP  KDE would not switch to this layout"
 


### PR DESCRIPTION
## Upgrading asked for a password you couldn't type

Reported from a Steam Deck: re-running the installer prompted for sudo *after* the keyboard had gone, leaving nothing to answer it with.

Two things wrong, both fixed:

- The privileged step ran **last**. It now runs **first**, while whatever keyboard you started with is still alive.
- On an upgrade it shouldn't run at all — the udev rule and `input` group survive from the previous install. The installer checks and says so:

```
:: Keyboard-injection permission already in place — no password needed.
```

Verified by re-running the installer on a Deck that already had it: no prompt, no warning.

## 🌐 named the country, not the language

`il` is Israel, not Hebrew. `in` is India, not Hindi. `latam` didn't fit on a key. `us` and `gb` are both English.

| was | now |
|---|---|
| 🌐IL | 🌐עב |
| 🌐IN | 🌐हि |
| 🌐ARA | 🌐ع |
| 🌐TH | 🌐ไทย |
| 🌐GR | 🌐ΕΛ |

Latin layouts keep their familiar two letters. Badges are generated into `index.json`; an older index without them still loads.

## The logout prompt missed swaps

It compared layout *counts*. Swapping Russian for Vietnamese is four for four — and it's the change anyone is most likely to make — so the config changed and nothing was said. It compares the sets against what KWin is really running now. Verified both ways on a Legion Go 2.

## Picker

Shows what's in rotation before you change it, states the four-at-a-time rule up front, and confirms rather than silently truncating on: more than four ticked, none ticked, or four with no Latin layout (which breaks Ctrl+S — see rc7).

## Currency in the language test

Most layouts keep currency on the third level — `€` on AltGr-E, plus `₺ ₽ ₪ ฿ ₫ ₯` — so typing them exercises AltGr and the level-3 labels in the spot a user would most notice being wrong. Symbols come from each layout's own data, not from assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)