### PR TITLE
Make uninstall actually uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,20 @@ same way. KDE's Latin fallback covers global shortcuts, not an application's own
 by this test failing every save under `ru ua gr ara`, and passing the moment `us` was in
 the group. `handheld-kbd-locales` now warns when a selection has no Latin layout.
 
+### Fixed since rc9
+
+- **Uninstalling actually uninstalls.** The removal list was written once and never kept
+  up: by v1.0.11 it named seven of the eighteen files an install puts in `~/.local/bin`,
+  so "Uninstalled." left most of the program behind, along with two autostart entries and
+  the bundled suggestion filter. It matches `handheld-kbd-*` now, which is what everything
+  this project installs is called.
+- **Uninstalling stops the keyboard for good.** It used `pkill`, and the supervisor runs
+  as a systemd unit — so the process died and a fresh one arrived two seconds later. The
+  units are stopped first.
+- **The KWin script is unloaded, not just deleted.** It keeps running in the session after
+  its file is gone, so the desktop was still being driven by a keyboard that no longer
+  existed.
+
 ### Fixed since rc8
 
 - **Upgrading no longer asks for a password you cannot type.** The privileged step —

--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ keyboard restarts. Layouts and locales sit beside it as plain JSON.
 
 ## Uninstall
 
-`./uninstall.sh` (your config is left in place).
+`./uninstall.sh` — removes the program, autostart, shortcuts, the KWin script and
+the udev rule. Your config in `~/.config/handheld-kbd/` is left in place; delete it
+yourself if you want the learned predictions gone too.
 
 ## Requirements
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,24 +6,33 @@ RULE_UUID="a8a95de3-82aa-4998-87c0-125fb8525143"
 say() { printf '\033[1;36m::\033[0m %s\n' "$*"; }
 
 say "Stopping running keyboard…"
+# Units first. They are what restarts the supervisor, so pkill on its own removes the
+# process and gets a fresh one two seconds later.
+systemctl --user stop handheld-kbd handheld-kbd-tray 2>/dev/null
+systemctl --user reset-failed handheld-kbd handheld-kbd-tray 2>/dev/null
 pkill -f 'python3 .*handheld-kbd\.py' 2>/dev/null
+pkill -f 'python3 .*handheld-kbd-tray' 2>/dev/null
 pkill -f 'handheld-kbd-swap\.sh' 2>/dev/null
 
 say "Removing program + autostart + KWin script…"
-rm -f "$HOME/.local/bin/handheld-kbd.py" \
-      "$HOME/.local/bin/handheld-kbd-swap.sh" \
-      "$HOME/.local/bin/handheld-kbd-relogin" \
-      "$HOME/.local/bin/handheld-kbd-ip-remap" \
-      "$HOME/.local/bin/handheld-kbd-ctl" \
-      "$HOME/.local/bin/handheld-kbd-locales" \
-      "$HOME/.local/bin/handheld-kbd-tray" \
-      "$HOME/.config/autostart/handheld-kbd-tray.desktop" \
-      "$HOME/.config/autostart/handheld-kbd.desktop" \
-      "$HOME/.config/autostart/handheld-kbd-swap.desktop"
+# Glob rather than a list of names. The list was written once and never kept up: by
+# v1.0.11 it named seven of the eighteen files an install puts in ~/.local/bin, so
+# "uninstalled" left most of the program behind. Anything this project installs is
+# named handheld-kbd-* or handheld_kbd_*, so match that and nothing else.
+rm -f "$HOME"/.local/bin/handheld-kbd-* \
+      "$HOME"/.local/bin/handheld-kbd.py \
+      "$HOME"/.local/bin/handheld_kbd_*.py
+rm -f "$HOME"/.config/autostart/handheld-kbd-*.desktop \
+      "$HOME"/.config/autostart/handheld-kbd.desktop \
+      "$HOME"/.config/autostart/handheld-kbd*.desktop.disabled
 rm -f "$HOME"/.local/share/applications/handheld-kbd-*.desktop
 command -v update-desktop-database >/dev/null 2>&1 && \
   update-desktop-database "$HOME/.local/share/applications" 2>/dev/null
 rm -rf "$HOME/.local/share/kwin/scripts/handheld-kbd-opacity"
+rm -rf "$HOME/.local/lib/handheld-kbd"          # the bundled suggestion filter
+# The script keeps running in the session after its files are gone — unload it, or the
+# desktop is still being driven by a keyboard that no longer exists.
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript handheld-kbd-opacity >/dev/null 2>&1 || true
 
 # restore the hardware keyboard button (we remapped it via InputPlumber)
 say "Restoring InputPlumber default profile…"


### PR DESCRIPTION
Found while wiping a Steam Deck for a fresh-install test — and finding it wasn't wiped.

`./uninstall.sh` printed "Uninstalled." and left behind:

```
11 binaries  handheld-kbd-build-dict, -dock-rect, -fix-pointer, -focus-probe,
             -install-filter, -kwin-script, -recover, -resume-watch.py,
             -resume-watch.sh, -resume.sh, -toggle, handheld_kbd_{predict,swipe}.py
 2 autostart handheld-kbd-resume.desktop (+ .disabled leftovers)
 1 vendor    ~/.local/lib/handheld-kbd  (bundled suggestion filter)
```

The removal list was written by hand once and never kept up — it named 7 of the 18 files an install creates. It now matches `handheld-kbd-*` / `handheld_kbd_*`, which is what everything this project installs is called, so the next file added is covered without anyone remembering.

Two more faults in the same script:

- **`pkill` doesn't stop the keyboard.** The supervisor runs as a systemd unit, so the process died and a fresh one arrived two seconds later. Units are stopped first.
- **The KWin script was deleted but not unloaded**, leaving the session driven by a keyboard whose files no longer existed.

Verified on a Steam Deck:

```
binaries: 0   autostart: 0   shortcuts: 0   config: gone
filter: gone  kwin script: gone + unloaded
udev rule: gone   in input group: no
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)