### PR TITLE
Never label a key with a character it cannot type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,18 @@ same way. KDE's Latin fallback covers global shortcuts, not an application's own
 by this test failing every save under `ru ua gr ara`, and passing the moment `us` was in
 the group. `handheld-kbd-locales` now warns when a selection has no Latin layout.
 
+### Fixed since rc10
+
+- **No key is labelled with a character it cannot type.** A layout can define symbols on
+  the third level and bind nothing to reach them, and Russian does exactly that: the
+  rouble sits on level 3 of the `8` key while `RALT` stays `Alt_R`, so `₽` was drawn on a
+  key no keypress could produce. Level-3 labels are now emitted only for layouts that
+  actually provide an AltGr switch — which drops them for `ru`, and confirms `us` and
+  `th` never had any. CI fails a locale that claims otherwise.
+
+  Found by the language test typing each layout's currency symbols: `₽` was the one
+  character out of twenty languages that went in and did not come back.
+
 ### Fixed since rc9
 
 - **Uninstalling actually uninstalls.** The removal list was written once and never kept

--- a/config/locales/ru.json
+++ b/config/locales/ru.json
@@ -32,7 +32,6 @@
     "shifted": "?"
   },
   "KEY_8": {
-    "alt": "₽",
     "label": "8",
     "shifted": "*"
   },

--- a/tools/build-locales.py
+++ b/tools/build-locales.py
@@ -236,6 +236,29 @@ class Symbols:
                 best = body
         return best or ""
 
+    def has_level3(self, name, variant=None, seen=None):
+        """True if this layout gives you a way to REACH the third level.
+
+        A layout can define level-3 symbols and provide no key to shift to them. The
+        Russian layout does exactly that: the rouble sits on level 3 of the 8 key, and
+        nothing in the layout binds AltGr — RALT stays Alt_R. Drawing ₽ on the key would
+        promise a character no keypress can produce, which is the failure this whole
+        generator exists to avoid.
+        """
+        seen = seen if seen is not None else set()
+        key = (name, variant)
+        if key in seen:
+            return False
+        seen.add(key)
+        body = self.block(name, variant)
+        if "level3(" in body or "level5(" in body:
+            return True
+        for inc in _INCLUDE_RE.findall(body):
+            m = re.fullmatch(r"([\w+/-]+)(?:\(([\w-]+)\))?", inc.strip())
+            if m and self.has_level3(m.group(1), m.group(2), seen):
+                return True
+        return False
+
     def levels(self, name, variant=None, seen=None):
         """{xkb key name: [level1, level2, level3, ...]} with includes merged in first."""
         seen = seen if seen is not None else set()
@@ -277,6 +300,7 @@ class Symbols:
 
 def build(code, syms, table):
     levels = syms.levels(code)
+    altgr = syms.has_level3(code)
     out = {}
     for xkbname, entry in levels.items():
         evdev = XKB_TO_EVDEV.get(xkbname)
@@ -293,7 +317,7 @@ def build(code, syms, table):
         # printing it in the corner of the key is noise.
         if shifted and shifted != label and shifted != label.upper():
             rec["shifted"] = shifted
-        if alt and alt not in (label, shifted):
+        if altgr and alt and alt not in (label, shifted):
             rec["alt"] = alt
         out[evdev] = rec
     return out
@@ -339,7 +363,8 @@ def main():
             f.write("\n")
         index[code] = {"name": name, "badge": badge}
         alt = sum(1 for v in data.values() if "alt" in v)
-        print(f"  {code:6s} {len(data):3d} keys, {alt:3d} with AltGr  — {name}")
+        note = "" if syms.has_level3(code) else "   (no AltGr switch in this layout)"
+        print(f"  {code:6s} {len(data):3d} keys, {alt:3d} with AltGr  — {name}{note}")
 
     with open(os.path.join(OUT, "index.json"), "w", encoding="utf-8") as f:
         json.dump(index, f, indent=2, ensure_ascii=False, sort_keys=True)

--- a/tools/verify-locales.py
+++ b/tools/verify-locales.py
@@ -97,6 +97,15 @@ def main():
         ours = json.load(open(os.path.join(LOCALES, f"{code}.json")))
         theirs = keymap_levels(text)
         bad = []
+        # A level-3 label is a promise the layout may not keep: it can define symbols on
+        # the third level and bind no key to reach them. Russian did — the rouble sat on
+        # a key no keypress could produce.
+        ralt = re.search(r"key <RALT>.*?\};", text, re.S)
+        if ralt and "ISO_Level3_Shift" not in ralt.group(0):
+            unreachable = [k for k, v in ours.items() if "alt" in v]
+            if unreachable:
+                bad.append(f"{len(unreachable)} AltGr label(s) but this layout has no "
+                           f"level-3 switch: {', '.join(sorted(unreachable)[:4])}…")
         # A short locale file is how every parser bug so far presented: the layout looked
         # right and had quietly lost keys off the end.
         expected = len(XKB_TO_EVDEV)


### PR DESCRIPTION
The currency pangrams found one character out of twenty languages that was typed and didn't arrive: Russian `₽`.

Not a parser bug. The label matched the keymap exactly — the keymap is what makes the unkeepable promise:

```
key <AE08>  { [ 8, asterisk, U20BD, NoSymbol ] };   # rouble on level 3
key <RALT>  { [ Alt_R ] };                          # …and nothing reaches level 3
```

A layout can define third-level symbols and bind no AltGr switch. So we drew `₽` on a key no keypress could produce — precisely the failure this generator exists to prevent.

Level-3 labels are now emitted only for layouts that provide an AltGr switch, decided by walking the include chain for `level3()`. Effect across the twenty:

```
ru   1 → 0 AltGr labels   (rouble was unreachable)
us   0 → 0                (confirmed: never had a switch)
th   0 → 0                (same)
17 others unchanged
```

`verify-locales.py` now fails any locale carrying AltGr labels when the compiled keymap leaves `RALT` as `Alt_R`, so CI catches the next one rather than a pangram doing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)