### PR TITLE
Close Steam's OSK in every trigger mode, not just mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
+## v1.0.12 — The pointer survives every trigger mode
+
+Verified on both machines before tagging: on a Legion Go 2 (`mirror: false`), opening
+Steam's OSK now logs `Set OSK active 1` → `0` within the same second and no window is
+left behind; on a Steam Deck (`mirror: true`), the keyboard button still summons and
+dismisses the keyboard exactly as in v1.0.11, with Steam's OSK closed on each press.
+
+### Fixed
+
+- **Dead trackpad and stick pointer on devices that don't mirror Steam's OSK.** While a
+  "Steam Input On-screen Keyboard" window exists — even at zero opacity — Steam holds the
+  controller in its KB ActionSet, where the sticks and trackpads navigate that keyboard
+  instead of moving the desktop pointer. The KWin script made Steam's OSK transparent in
+  every trigger mode, but only *closed* it in mirror mode. So a Deck (mirror) got its
+  pointer back, while a device on the DBus or hotkey trigger (`mirror: false`) collected
+  an invisible-but-mapped Steam OSK the first time anything opened it — a controller
+  focusing a text field, `steam steam://open/keyboard` — and lost its pointer until
+  `handheld-kbd-fix-pointer` was run by hand. The close now fires in every trigger mode;
+  mirror mode's summon/dismiss toggle is untouched.
+
 ## v1.0.11 — Twenty languages
 
 Every one of the twenty languages has been typed into Kate on real hardware — pangram

--- a/bin/handheld-kbd-kwin-script
+++ b/bin/handheld-kbd-kwin-script
@@ -312,7 +312,14 @@ function closeSteamOsk(w){
 
 function onAdded(w){
     setOp(w); watch(w); dockKbd(w); applyStack();
-    if (MIRROR && isSteamOsk(w)) onSteamOsk(w);
+    // Steam's OSK must never be left mapped-but-invisible in ANY trigger mode: setOp
+    // just made it transparent, and while it exists Steam holds the controller in its
+    // KB ActionSet — no trackpad or stick pointer. Mirror mode also toggles our
+    // keyboard off the event; other modes have their own trigger, so just close it.
+    if (isSteamOsk(w)) {
+        if (MIRROR) onSteamOsk(w);
+        else if (CLOSE_STEAM) closeSteamOsk(w);
+    }
     // When our OSK maps, the summon (touch gesture / map) may have shifted focus.
     // Re-assert the window the user was on so typed keys land there. keepBelow keeps
     // a demoted fullscreen window below the OSK even once it is active again.
@@ -332,8 +339,9 @@ workspace.windowList().forEach(function(w){
     dockKbd(w);
     // A Steam OSK left over from before this script loaded is still holding the
     // controller in KB ActionSet. Close it on sight — this is what gives a Deck its
-    // trackpad and stick pointer back without restarting Steam.
-    if (MIRROR && CLOSE_STEAM && isSteamOsk(w)) closeSteamOsk(w);
+    // trackpad and stick pointer back without restarting Steam. In every mode: an
+    // opacity-0 leftover kills the pointer whether or not we mirror it.
+    if (CLOSE_STEAM && isSteamOsk(w)) closeSteamOsk(w);
 });
 workspace.windowAdded.connect(onAdded);
 workspace.windowRemoved.connect(function(w){


### PR DESCRIPTION
While a "Steam Input On-screen Keyboard" window exists — even at opacity 0 — Steam holds the controller in its KB ActionSet and the trackpad/stick pointer is dead. The KWin script hid Steam's OSK in every mode but only closed it in mirror mode, so non-mirror devices (DBus/hotkey trigger, e.g. Legion Go 2) lost the pointer the first time anything opened Steam's OSK.

Close on sight in every trigger mode; mirror's summon/dismiss toggle unchanged. Verified live on a Steam Deck (mirror) and a Legion Go 2 (non-mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdxTHD185g4doKrvMh8gM