### PR TITLE
Align arrow inverted-T + see-through normal keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
+## v1.0.17 — Aligned arrows, see-through keyboard
+
+### Fixed
+
+- **The arrow keys line up.** `↑` now sits directly above `↓` — a proper inverted-T
+  with `←` and `→` either side — in both the normal and the split keyboard. Spacer
+  cells in the layout hold the arrows in their column no matter how long the row is.
+
+### Changed
+
+- **The whole keyboard is see-through.** In desktop mode only the key tiles paint
+  now; the window itself is transparent, so the space between and around the keys
+  shows the desktop through instead of a grey slab. The split keyboard already did
+  this — the normal keyboard now matches, so it's just as space-efficient.
+
 ## v1.0.16 — Split keyboard
 
 A split-keyboard mode for thumb-typing while you grip the device: the keyboard

--- a/bin/handheld-kbd.py
+++ b/bin/handheld-kbd.py
@@ -272,7 +272,7 @@ def resolve_rows(layout):
         row = []
         for k in jrow:
             kind = k.get("kind", "")
-            if kind in ("locale", "hide", "size", "opacity", "move", "reset"):
+            if kind in ("locale", "hide", "size", "opacity", "move", "reset", "blank"):
                 dflt = {"locale": "🌐", "hide": "⌵", "size": "⤢",
                         "opacity": "◐", "move": "✥", "reset": "⤓"}.get(kind, "")
                 row.append((k.get("label", dflt), None, kind, "", ""))
@@ -306,9 +306,9 @@ button.suggest:active {{ background: {t['key_active']}; }}
 button.suggest-empty {{ background: transparent; border-color: transparent; }}
 window.gm {{ background-color: rgba(0,0,0,0); }}
 .gm-keys {{ background-color: rgba(12,12,12,0.82); }}
-/* Split mode: fully transparent — only the key tiles paint. No panel slab behind
-   the keys, so the space between keys and beside the shorter rows is empty too. */
-window.splitwin {{ background-color: rgba(0,0,0,0); }}
+/* Desktop mode (split or not): fully transparent — only the key tiles paint, so the
+   space between and around the keys shows the desktop through, never a grey slab. */
+window.clearwin {{ background-color: rgba(0,0,0,0); }}
 .kbpanel {{ background-color: transparent; }}
 /* Free movement is self-evident once the bar is there — a lit-up blue block on top of
    that is noise. Muted bar, muted grips, and the key gets an outline rather than a fill. */
@@ -355,7 +355,7 @@ class OSK(Gtk.Window):
         # Uniform aligned grid: every key snaps to a column grid (column_homogeneous),
         # widths come from per-kind unit spans, rows centred → tidy, even alignment.
         kh = config["key_size"][1]
-        SPAN = {'': 2, 'wide': 3, 'mod': 3, 'space': 8, 'locale': 2, 'hide': 2, 'reset': 2, 'size': 2, 'opacity': 2}
+        SPAN = {'': 2, 'wide': 3, 'mod': 3, 'space': 8, 'locale': 2, 'hide': 2, 'reset': 2, 'size': 2, 'opacity': 2, 'blank': 2}
         row_units = [sum(SPAN.get(k[2], 2) for k in row) for row in rows]
         maxu = max(row_units) if row_units else 1
         # Split mode: two independent keyboard panels pushed to the left and right
@@ -406,6 +406,12 @@ class OSK(Gtk.Window):
         def attach_key(grid, ri, col, key):
             (label, kc, kind, shifted, name) = key
             sp = SPAN.get(kind, 2)
+            if kind == 'blank':
+                # An empty placeholder cell — occupies grid space (so keys above/below it
+                # stay aligned, e.g. the arrow inverted-T) but paints and does nothing.
+                gap = Gtk.Box(); gap.set_can_focus(False)
+                grid.attach(gap, col, ri, sp, 1)
+                return
             b = Gtk.Button(label=label)
             # A label must never dictate the window's size. The grid is column-homogeneous,
             # so ONE wide label widens every column — the 🌐 key reading "🌐LATAM" pushed the
@@ -487,15 +493,16 @@ class OSK(Gtk.Window):
         self.handle = self._build_handle()
         self.handle.set_no_show_all(True)
         self.orig_touch_mode = None
-        # Split mode paints nothing behind the keys — the window is transparent and only
-        # the two panels carry a background, so the middle gap and the space around the
-        # panels are truly empty (the desktop shows through), not a translucent slab.
-        if self.split and not GAMEMODE:
+        # Desktop mode paints nothing behind the keys — the window is transparent and only
+        # the key tiles carry a background, so the space between and around the keys is
+        # truly empty (the desktop shows through), not a translucent slab. Same in split
+        # (the middle gap shows through too) and non-split (just as space-efficient).
+        if not GAMEMODE:
             vis = self.get_screen().get_rgba_visual()
             if vis is not None:
                 self.set_visual(vis)
             self.set_app_paintable(True)
-            self.get_style_context().add_class("splitwin")
+            self.get_style_context().add_class("clearwin")
         if GAMEMODE:
             # Transparent fullscreen overlay: gamescope fullscreens us, the game shows
             # through the transparent top, keys docked at the bottom on a dark strip.

--- a/config/layouts/full.json
+++ b/config/layouts/full.json
@@ -317,8 +317,17 @@
         "shifted": "?"
       },
       {
+        "kind": "blank"
+      },
+      {
         "label": "↑",
         "key": "KEY_UP"
+      },
+      {
+        "kind": "blank"
+      },
+      {
+        "kind": "blank"
       }
     ],
     [


### PR DESCRIPTION
Two small fixes on top of v1.0.16.

### Arrow alignment
`↑` sat ~half a key right of `↓` in the normal keyboard (and ~2 keys off in split) because the zxcv row and the bottom row are different widths, so their centring/right-align offsets differ. Added a **`blank` spacer key kind** and padded the zxcv row (one spacer before `↑`, two after) so it matches the bottom rows width and `↑` lands in the same column as `↓` — a clean inverted-T with `←`/`→` either side, verified in **both** normal and split modes.

### See-through normal keyboard
The split keyboard already ran on a transparent window (only key tiles paint). Dropped the `self.split` guard so the **normal** keyboard does too (window class `splitwin` → `clearwin`) — the desktop shows through the gaps instead of a grey slab, so its just as space-efficient.

### Caveat
`install.sh` never clobbers an existing layout, so the arrow fix (a `full.json` change) reaches **new installs** but not upgrades; the code changes reach both. Both devices will be synced manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)