### PR TITLE
Propagate the arrow alignment to existing layouts on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
 
 The heading must be `## v<version> — <title>` and the version must match the tag.
 
+## v1.0.18 — Upgrades pick up the aligned arrows
+
+### Fixed
+
+- **Upgrading now aligns the arrows on a layout you already have.** v1.0.17 fixed
+  the arrow inverted-T, but since `install.sh` never overwrites an existing layout,
+  the fix only reached fresh installs. The upgrade step now recognises a layout
+  that is an un-spaced copy of the shipped one and brings the spacer cells in, so an
+  upgrade gets the aligned arrows too. Layouts you've customised are left untouched.
+
 ## v1.0.17 — Aligned arrows, see-through keyboard
 
 ### Fixed

--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,11 @@ def save(p, data):
         f.write("\n")
     os.replace(tmp, p)
 
+def strip_blanks(rows):
+    # A layout with the shipped one's spacer cells removed. Used to tell whether a user's
+    # layout is just an un-aligned copy of ours (same keys, missing only the blank spacers).
+    return [[k for k in row if k.get("kind") != "blank"] for row in rows]
+
 for name in sorted(os.listdir(os.path.join(SRC, "layouts"))):
     if not name.endswith(".json"):
         continue
@@ -146,6 +151,17 @@ for name in sorted(os.listdir(os.path.join(SRC, "layouts"))):
     except Exception as ex:
         print(f"handheld-kbd: skipping {name} ({ex})", file=sys.stderr)
         continue
+    notes = []
+    # Spacer/alignment upgrade: if the user's layout is exactly this shipped layout with
+    # the blank spacer cells taken out, it's an un-aligned copy from before we added them
+    # (e.g. the arrow inverted-T). Adopt the shipped rows so the alignment reaches upgrades
+    # too — layouts are never clobbered otherwise. Skipped the moment they've customised
+    # anything (the rows stop matching) or already have the spacers (idempotent).
+    if (shipped.get("rows") != mine.get("rows")
+            and strip_blanks(shipped.get("rows", [])) == mine.get("rows", [])):
+        mine["rows"] = shipped["rows"]
+        notes.append("aligned spacers")
+
     have = {k.get("kind") for row in mine.get("rows", []) for k in row}
     have_keys = {k.get("key") for row in mine.get("rows", []) for k in row}
     added = []
@@ -163,9 +179,11 @@ for name in sorted(os.listdir(os.path.join(SRC, "layouts"))):
             have_keys.add(kname)
             added.append(key.get("label") or kind or kname)
     if added:
+        notes.append("added " + " ".join(added))
+    if notes:
         shutil.copy(dp, dp + ".bak")
         save(dp, mine)
-        print(f"handheld-kbd: added {' '.join(added)} to {name}")
+        print(f"handheld-kbd: {name}: {'; '.join(notes)}")
 
 cfg = os.path.join(DST, "config.json")
 try:


### PR DESCRIPTION
v1.0.17 aligned the arrow inverted-T in the shipped `full.json`, but `install.sh` never clobbers a layout you already have — so the fix only reached **new** installs.

This adds a step to the layout-upgrade migration: if a users layout is exactly the shipped one **with the blank spacer cells removed**, it adopts the shipped rows, pulling the spacers (and thus the alignment) in.

- **Safe:** fires only on an unmodified stock layout — the rows stop matching the moment anything is customised, so custom layouts are untouched.
- **Idempotent:** once the spacers are present the layout no longer matches the stripped shipped one, so re-running is a no-op.

Verified against a real v1.0.16 layout: run once → aligned to v1.0.17; run again → no-op; `compact.json` and a customised layout both left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)